### PR TITLE
[김보민] week4-deleted

### DIFF
--- a/css/signin.css
+++ b/css/signin.css
@@ -11,7 +11,6 @@ html {
 body {
   height: 100%;
   position: relative;
-  width: 100%;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -68,9 +67,7 @@ label {
   color: black;
   font-family: Pretendard;
   font-size: 14px;
-  font-style: normal;
   font-weight: 400;
-  line-height: normal;
 }
 
 input {
@@ -162,8 +159,31 @@ input:focus {
   right: 10px;
 }
 
-.pwd-input {
+.error-msg {
+  margin-top:6px;
+  color:#FF5B56;
+  font-size: 14px;
+}
+
+.hide {
+  display: none;
+}
+
+.error-border {
+  border-color:#FF5B56;
+}
+
+.pwd-input-wrapper {
   margin-top: 24px;
+  position: relative;
+}
+
+.pwd-eye-off {
+  position: absolute;
+  padding:0;
+  height: 16px;
+  top: 50px;
+  right: 15px;
 }
 
 .pwd-input-check {
@@ -176,10 +196,6 @@ input:focus {
   font-family: Pretendard;
   font-weight: 400;
   margin-top: 6px;
-}
-
-.pwd-input-check input{
-  border-color: red;
 }
 
 .pwd-input form {

--- a/css/signin.css
+++ b/css/signin.css
@@ -89,7 +89,6 @@ input:focus {
   border: 1px #6D6AFE solid;
 }
 
-
 .button-sign {
   width: 100%;
   padding: 16px 20px;
@@ -125,7 +124,7 @@ input:focus {
   font-weight: 400;
 }
 
-.social-login .image2 {
+.social-login .kakao-icon {
   width: 42px;
   height: 42px;
   background-color: #FEE500;
@@ -133,7 +132,7 @@ input:focus {
   position: relative;
 }
 
-.social-login .image1 {
+.social-login .google-icon {
   width: 42px;
   height: 42px;
   background-color: #FFFFFF;
@@ -143,7 +142,7 @@ input:focus {
   box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 }
 
-.image2 img {
+.kakao-icon img {
   position: absolute;
   top: 10px;
   bottom: 8px;
@@ -151,7 +150,7 @@ input:focus {
   right: 8px;
 }
 
-.image1 img {
+.google-icon img {
   position: absolute;
   top: 10px;
   bottom: 10px;

--- a/signin.html
+++ b/signin.html
@@ -38,7 +38,7 @@
           <li class="pwd-input-wrapper">
             <label>
               비밀번호 <br>
-              <input class="pwd-input error-border" name="focus" type="password">       
+              <input class="pwd-input error-border" value="" type="password">       
             </label>
             <button class="pwd-eye-off">
               <img src="images/eye-off.svg" alt="eye-off">
@@ -53,12 +53,12 @@
     <div class="social-login">
       <p>소셜 로그인</p>
       <div class="social-icon">
-        <div class="image1">
+        <div class="google-icon">
           <a href="http://www.google.com">
             <img src="images/google.png" alt="구글 아이콘">
           </a>
         </div>
-        <div class="image2">
+        <div class="kakao-icon">
           <a href="http://www.kakao.com">
             <img src="images/99FE484C5C3451F218 1.svg" alt="카카오 아이콘">
           </a>

--- a/signin.html
+++ b/signin.html
@@ -13,9 +13,9 @@
 <body>
   <div class="contents">
     <div class="title">
-      <div class="logo">
+      <div>
         <a href="/"> 
-          <img src="images/logo.svg" alt="로고">
+          <img class="logo" src="images/logo.svg" alt="로고">
         </a>
       </div>
       <h2>
@@ -24,26 +24,32 @@
       </h2>
     </div>
     <div class="input-form">
-      <div class="email-input">
-        <form>
-          <ol>
-            <li>
-              <label>
-                이메일 <br>
-                <input type="email">
-              </label>
-            </li>
-            <li class="pwd-input">
-              <label>
-                비밀번호 <br>
-                <input name="focus" type="password">       
-              </label>
-            </li>
-          </ol>
-        </form>
-      </div>
+      <form>
+        <ol>
+          <li class="email-input-wrapper">
+            <label>
+              이메일 <br>
+              <input class="email-input error-border" value="" type="email">
+            </label>
+            <p class="error-msg email-blank-error">이메일을 입력해주세요</p>
+            <p class="error-msg email-type-error hide">올바른 이메일 주소가 아닙니다.</p>
+            <p class="error-msg check-email hide">이메일을 확인해주세요</p>
+          </li>
+          <li class="pwd-input-wrapper">
+            <label>
+              비밀번호 <br>
+              <input class="pwd-input error-border" name="focus" type="password">       
+            </label>
+            <button class="pwd-eye-off">
+              <img src="images/eye-off.svg" alt="eye-off">
+            </button>
+            <p class="error-msg pwd-blank-error">비밀번호를 입력해주세요</p>
+            <p class="error-msg check-pwd hide">비밀번호를 확인해주세요</p>
+          </li>
+        </ol>
+      </form>
     </div>
-    <button class="button-sign"> 로그인 </button>
+    <button class="button-sign" onclick="loginCheck()"> 로그인 </button>
     <div class="social-login">
       <p>소셜 로그인</p>
       <div class="social-icon">
@@ -60,4 +66,5 @@
       </div>
     </div>
   </div>
+  <script src="signin.js"></script>
 </body>

--- a/signin.js
+++ b/signin.js
@@ -3,10 +3,11 @@ const pwdInput=document.querySelector('.pwd-input');
 const loginButton=document.querySelector('.button-sign');
 const checkEmail= document.querySelector('.check-email');
 const checkPwd= document.querySelector('.check-pwd');
+const eyeIcon=document.querySelector('.pwd-eye-off');
 
 function emailCheck(email_address){		
     const email_regex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
-    if(!email_regex.test(email_address)){ 
+    if(!email_regex.test(email_address)) { 
         return false; 
     } else{
         return true;
@@ -24,10 +25,6 @@ function loginCheck() {
     }
 }
 
-function errorBorder() {
-    this.classList.toggle('error-border');
-}
-
 emailInput.addEventListener('focusout',(e)=>{
     const blankError=document.querySelector('.email-blank-error');
     const typeError=document.querySelector('.email-type-error');
@@ -42,7 +39,6 @@ emailInput.addEventListener('focusout',(e)=>{
         blankError.classList.remove('hide');
         typeError.classList.add('hide');
     } 
-
     if (blankError.classList.contains('hide') && typeError.classList.contains('hide')) {
         emailInput.classList.remove('error-border');
     } else {
@@ -57,7 +53,6 @@ emailInput.addEventListener('focusin',(e)=>{
 
 pwdInput.addEventListener('focusout',(e)=>{
     const blankError=document.querySelector('.pwd-blank-error');
-    console.log(pwdInput.value);
     if (pwdInput.value !== '') {
         blankError.classList.add('hide'); 
         pwdInput.classList.remove('error-border');
@@ -83,4 +78,12 @@ pwdInput.addEventListener('keyup',(e)=>{
     if (e.keyCode===13) {
         loginCheck();
     }
+});
+
+eyeIcon.addEventListener('mousedown',()=>{
+    pwdInput.setAttribute('type','text');
+});
+
+eyeIcon.addEventListener('mouseup',()=>{
+    pwdInput.setAttribute('type','password');
 });

--- a/signin.js
+++ b/signin.js
@@ -1,0 +1,86 @@
+const emailInput= document.querySelector('.email-input');
+const pwdInput=document.querySelector('.pwd-input');
+const loginButton=document.querySelector('.button-sign');
+const checkEmail= document.querySelector('.check-email');
+const checkPwd= document.querySelector('.check-pwd');
+
+function emailCheck(email_address){		
+    const email_regex = /^[a-zA-Z0-9._-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,4}$/i;
+    if(!email_regex.test(email_address)){ 
+        return false; 
+    } else{
+        return true;
+    }
+}
+
+function loginCheck() {
+    if ((emailInput.value==='test@codeit.com')&&pwdInput.value==='codeit101') {
+        location.href='folder.html';
+    } else {
+        checkEmail.classList.remove('hide');
+        emailInput.classList.add('error-border');
+        checkPwd.classList.remove('hide');
+        pwdInput.classList.add('error-border');
+    }
+}
+
+function errorBorder() {
+    this.classList.toggle('error-border');
+}
+
+emailInput.addEventListener('focusout',(e)=>{
+    const blankError=document.querySelector('.email-blank-error');
+    const typeError=document.querySelector('.email-type-error');
+    if (emailInput.value !== '') {
+        blankError.classList.add('hide');
+        if(!emailCheck(emailInput.value)) {
+            typeError.classList.remove('hide');
+        } else {
+            typeError.classList.add('hide');
+        }
+    } else {
+        blankError.classList.remove('hide');
+        typeError.classList.add('hide');
+    } 
+
+    if (blankError.classList.contains('hide') && typeError.classList.contains('hide')) {
+        emailInput.classList.remove('error-border');
+    } else {
+        emailInput.classList.add('error-border');
+    }
+});
+
+emailInput.addEventListener('focusin',(e)=>{
+    checkEmail.classList.add('hide');
+    checkPwd.classList.add('hide');
+});
+
+pwdInput.addEventListener('focusout',(e)=>{
+    const blankError=document.querySelector('.pwd-blank-error');
+    console.log(pwdInput.value);
+    if (pwdInput.value !== '') {
+        blankError.classList.add('hide'); 
+        pwdInput.classList.remove('error-border');
+    }
+    else {
+        blankError.classList.remove('hide'); 
+        pwdInput.classList.add('error-border');
+    }
+});
+
+pwdInput.addEventListener('focusin',(e)=>{
+    checkEmail.classList.add('hide');
+    checkPwd.classList.add('hide');
+});
+
+emailInput.addEventListener('keyup',(e)=>{
+    if (e.keyCode===13) {
+        loginCheck();
+    }
+ });
+
+pwdInput.addEventListener('keyup',(e)=>{
+    if (e.keyCode===13) {
+        loginCheck();
+    }
+});

--- a/signup.html
+++ b/signup.html
@@ -26,25 +26,33 @@
     <div class="input-form">
       <form>
         <ol>
-          <li>
+          <li class="email-input-wrapper">
             <label>
               이메일 <br>
-              <input type="email">
+              <input class="email-input error-border" value="" type="email">
             </label>
+            <p class="error-msg email-blank-error">이메일을 입력해주세요</p>
+            <p class="error-msg email-type-error hide">올바른 이메일 주소가 아닙니다.</p>
+            <p class="error-msg check-email hide">이메일을 확인해주세요</p>
           </li>
-          <li class="pwd-input">
+          <li class="pwd-input-wrapper">
             <label>
               비밀번호 <br>
+              <input class="pwd-input error-border" name="focus" type="password">       
+            </label>
+            <button class="pwd-eye-off">
+              <img src="images/eye-off.svg" alt="eye-off">
+            </button>
+            <p class="error-msg pwd-blank-error">비밀번호를 입력해주세요</p>
+            <p class="error-msg check-pwd hide">비밀번호를 확인해주세요</p>
+          </li>
+          <li class="pwd-input-check">
+            <label>
+              비밀번호 확인 <br>
               <input name="focus" type="password">       
             </label>
+            <p> 비밀번호와 다릅니다. </p>
           </li>
-            <li class="pwd-input-check">
-              <label>
-                비밀번호 확인 <br>
-                <input name="focus" type="password">       
-              </label>
-              <p> 비밀번호와 다릅니다. </p>
-            </li>
         </ol>
       </form>
     </div>


### PR DESCRIPTION
## 요구사항
netlify 주소: https://resonant-banoffee-19aa20.netlify.app/

### 기본
- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일: test@codeit.com, 비밀번호: codeit101 으로 로그인 시도할 경우, “/folder” 페이지로 이동하나요?
- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 없을 경우 아래에 “비밀번호를 입력해주세요.” 에러 메세지가 보이나요?
- [x] [기본]이외의 로그인 시도의 경우 이메일, 비밀번호 input에 빨강색 테두리와 각각의 input아래에 “이메일을 확인해주세요.”, “비밀번호를 확인해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일, 비밀번호 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?
- [x] [기본]로그인 버튼 클릭 또는 Enter키 입력으로 로그인 되나요?

### 심화

- [ ] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [ ] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?


## 주요 변경사항

- js파일 생성.
- 

## 스크린샷

<img width="535" alt="스크린샷 2024-03-10 오후 5 32 10" src="https://github.com/codeit-bootcamp-frontend/5-Weekly-Mission/assets/87798531/8565bcab-8d16-44d4-afb4-74815b97a1a7">
<img width="477" alt="스크린샷 2024-03-10 오후 5 32 38" src="https://github.com/codeit-bootcamp-frontend/5-Weekly-Mission/assets/87798531/1a647279-99bc-4987-9351-6f7b93d40238">
<img width="502" alt="스크린샷 2024-03-10 오후 5 33 26" src="https://github.com/codeit-bootcamp-frontend/5-Weekly-Mission/assets/87798531/2099f55a-4940-40e5-af81-bc3e75c6236b">


## 멘토에게

- 심화 요구사항 진행중에 눈아이콘 누르면 value가 초기화되는 오류가 해결이 안돼서 해결중입니다...
- 실수로 week3에 코드리뷰 수정사항 커밋했습니다..............

