### PR TITLE
[이현승] week 5

### DIFF
--- a/Index.html
+++ b/Index.html
@@ -22,7 +22,7 @@
       crossorigin
       href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css"
       />
-      <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
       href="https://fonts.googleapis.com/css2?family=Abel&display=swap"

--- a/auth.css
+++ b/auth.css
@@ -79,11 +79,11 @@ input:focus {
   outline: none;
 }
 
-.inputProblem {
+.inputError {
   border: 1px solid var(--red);
 }
 
-.inputProblem:focus {
+.inputError:focus {
   border: 1px solid var(--red);
   outline: 1px solid var(--red);
 }

--- a/idEmail.js
+++ b/idEmail.js
@@ -8,7 +8,6 @@ function resetLoginEmailError() {
 
 function isThisEmail(email) {
   const emailChecker = /^[a-zA-Z0-9]+@[a-zA-Z0-9]+\.[a-zA-Z0-9]+$/;
-  console.log(emailChecker.test(email));
   return emailChecker.test(email);
 } /* 이메일 형식이면 true를 뱉는 함수*/
 

--- a/idEmail.js
+++ b/idEmail.js
@@ -7,19 +7,9 @@ export function loginEmailErrorReset() {
 } /* 로그인 - 이메일 오류 메시지를 초기화 하는 함수  */
 
 function isThisEmail(email) {
-  const A = email.indexOf('@');
-  const B = email.indexOf('.');
-  if (
-    A === -1 ||
-    email.slice(0, A).length === 0 ||
-    email.slice(A + 1).length === 0 ||
-    B === -1 ||
-    B < A ||
-    email.slice(B + 1).length === 0
-  ) {
-    return false;
-  }
-  return true;
+  const emailChecker = /^[a-zA-Z0-9]+@[a-zA-Z0-9]+\.[a-zA-Z0-9]+$/;
+  console.log(emailChecker.test(email));
+  return emailChecker.test(email);
 } /* 이메일 형식이면 true를 뱉는 함수*/
 
 export const emailPls = function (e) {

--- a/idEmail.js
+++ b/idEmail.js
@@ -1,13 +1,12 @@
 export const emailInput = document.querySelector('#email');
+export const emailErrorMessage = document.querySelector('.emailErrorMessage');
 
 export function loginEmailErrorReset() {
-  document.querySelector('.giveMeEmail').classList.add('hidden');
-  document.querySelector('.notEmail').classList.add('hidden');
-  document.querySelector('.checkEmail').classList.add('hidden');
+  emailErrorMessage.classList.add('hidden');
   emailInput.classList.remove('inputError');
 } /* 로그인 - 이메일 오류 메시지를 초기화 하는 함수  */
 
-function isEmail(email) {
+function isThisEmail(email) {
   const A = email.indexOf('@');
   const B = email.indexOf('.');
   if (
@@ -26,11 +25,13 @@ function isEmail(email) {
 export const emailPls = function (e) {
   loginEmailErrorReset();
   if (emailInput.value === '') {
-    document.querySelector('.giveMeEmail').classList.remove('hidden');
+    emailErrorMessage.classList.remove('hidden');
+    emailErrorMessage.textContent = '이메일을 입력해 주세요.';
     emailInput.classList.add('inputError');
     return false;
-  } else if (isEmail(emailInput.value) === false) {
-    document.querySelector('.notEmail').classList.remove('hidden');
+  } else if (isThisEmail(emailInput.value) === false) {
+    emailErrorMessage.classList.remove('hidden');
+    emailErrorMessage.textContent = '올바른 이메일 주소가 아닙니다.';
     emailInput.classList.add('inputError');
     return false;
   }

--- a/idEmail.js
+++ b/idEmail.js
@@ -4,7 +4,7 @@ export function loginEmailErrorReset() {
   document.querySelector('.giveMeEmail').classList.add('hidden');
   document.querySelector('.notEmail').classList.add('hidden');
   document.querySelector('.checkEmail').classList.add('hidden');
-  emailInput.classList.remove('inputProblem');
+  emailInput.classList.remove('inputError');
 } /* 로그인 - 이메일 오류 메시지를 초기화 하는 함수  */
 
 function isEmail(email) {
@@ -27,11 +27,11 @@ export const emailPls = function (e) {
   loginEmailErrorReset();
   if (emailInput.value === '') {
     document.querySelector('.giveMeEmail').classList.remove('hidden');
-    emailInput.classList.add('inputProblem');
+    emailInput.classList.add('inputError');
     return false;
   } else if (isEmail(emailInput.value) === false) {
     document.querySelector('.notEmail').classList.remove('hidden');
-    emailInput.classList.add('inputProblem');
+    emailInput.classList.add('inputError');
     return false;
   }
   return true;

--- a/idEmail.js
+++ b/idEmail.js
@@ -1,7 +1,7 @@
 export const emailInput = document.querySelector('#email');
 export const emailErrorMessage = document.querySelector('.emailErrorMessage');
 
-export function loginEmailErrorReset() {
+function resetLoginEmailError() {
   emailErrorMessage.classList.add('hidden');
   emailInput.classList.remove('inputError');
 } /* 로그인 - 이메일 오류 메시지를 초기화 하는 함수  */
@@ -12,8 +12,8 @@ function isThisEmail(email) {
   return emailChecker.test(email);
 } /* 이메일 형식이면 true를 뱉는 함수*/
 
-export const emailPls = function (e) {
-  loginEmailErrorReset();
+export const checkEmail = function (e) {
+  resetLoginEmailError();
   if (emailInput.value === '') {
     emailErrorMessage.classList.remove('hidden');
     emailErrorMessage.textContent = '이메일을 입력해 주세요.';

--- a/linkbrary.css
+++ b/linkbrary.css
@@ -79,7 +79,6 @@ a {
   color: transparent;
   background: linear-gradient(91deg, #6d6afe 17.28%, #ff9f9f 74.98%);
   background-clip: text;
-  /* -webkit-text-fill-color: transparent; */
 }
 
 .link {

--- a/password.js
+++ b/password.js
@@ -26,11 +26,11 @@ export const checkPassword = function (e) {
 }; /* 비밀번호 입력하지 않으면 반응하는 함수 */
 
 export const hideShowpassword = function (e) {
-  e.target.parentElement.firstElementChild.classList.toggle('hidden');
-  e.target.parentElement.lastElementChild.classList.toggle('hidden');
-  if (e.target.parentElement.previousElementSibling.type === 'password') {
-    e.target.parentElement.previousElementSibling.type = 'text';
+  this.firstElementChild.classList.toggle('hidden');
+  this.lastElementChild.classList.toggle('hidden');
+  if (this.previousElementSibling.type === 'password') {
+    this.previousElementSibling.type = 'text';
   } else {
-    e.target.parentElement.previousElementSibling.type = 'password';
+    this.previousElementSibling.type = 'password';
   }
 }; /* 비밀번호 칸에서 눈을 눌러 비밀번호 보이기와 숨기기를 하게 하는 함수 */

--- a/password.js
+++ b/password.js
@@ -1,16 +1,19 @@
 export const passwordInput = document.querySelector('#password');
 export const passEyeButton = document.querySelector('.passEye');
+export const passwordErrorMessage = document.querySelector(
+  '.passwordErrorMessage'
+);
 
 function loginPassErrorReset() {
-  document.querySelector('.checkPassword').classList.add('hidden');
-  document.querySelector('.giveMePassword').classList.add('hidden');
+  passwordErrorMessage.classList.add('hidden');
   document.querySelector('#password').classList.remove('inputError');
 } /* 로그인 - 비밀번호 오류 메시지를 초기화 하는 함수 */
 
 export const passwordPls = function (e) {
   loginPassErrorReset();
   if (passwordInput.value === '') {
-    document.querySelector('.giveMePassword').classList.remove('hidden');
+    passwordErrorMessage.classList.remove('hidden');
+    passwordErrorMessage.textContent = '비밀번호를 입력해 주세요.';
     document.querySelector('#password').classList.add('inputError');
     return false;
   }

--- a/password.js
+++ b/password.js
@@ -1,10 +1,15 @@
 export const passwordInput = document.querySelector('#password');
+export const passwordCheckInput = document.querySelector('#passwordcheck');
 export const passEyeButton = document.querySelector('.passEye');
+export const passCheckEyeButton = document.querySelector('.passCheckEye');
 export const passwordErrorMessage = document.querySelector(
   '.passwordErrorMessage'
 );
+export const passwordcheckErrorMessage = document.querySelector(
+  '.passwordcheckErrorMessage'
+);
 
-function resetLoginPassError() {
+export function resetLoginPassError() {
   passwordErrorMessage.classList.add('hidden');
   document.querySelector('#password').classList.remove('inputError');
 } /* 로그인 - 비밀번호 오류 메시지를 초기화 하는 함수 */
@@ -20,12 +25,12 @@ export const checkPassword = function (e) {
   return true;
 }; /* 비밀번호 입력하지 않으면 반응하는 함수 */
 
-export const hideShowpassword = function () {
-  passEyeButton.firstElementChild.classList.toggle('hidden');
-  passEyeButton.lastElementChild.classList.toggle('hidden');
-  if (passwordInput.type === 'password') {
-    passwordInput.type = 'text';
+export const hideShowpassword = function (e) {
+  e.target.parentElement.firstElementChild.classList.toggle('hidden');
+  e.target.parentElement.lastElementChild.classList.toggle('hidden');
+  if (e.target.parentElement.previousElementSibling.type === 'password') {
+    e.target.parentElement.previousElementSibling.type = 'text';
   } else {
-    passwordInput.type = 'password';
+    e.target.parentElement.previousElementSibling.type = 'password';
   }
 }; /* 비밀번호 칸에서 눈을 눌러 비밀번호 보이기와 숨기기를 하게 하는 함수 */

--- a/password.js
+++ b/password.js
@@ -4,14 +4,14 @@ export const passEyeButton = document.querySelector('.passEye');
 function loginPassErrorReset() {
   document.querySelector('.checkPassword').classList.add('hidden');
   document.querySelector('.giveMePassword').classList.add('hidden');
-  document.querySelector('#password').classList.remove('inputProblem');
+  document.querySelector('#password').classList.remove('inputError');
 } /* 로그인 - 비밀번호 오류 메시지를 초기화 하는 함수 */
 
 export const passwordPls = function (e) {
   loginPassErrorReset();
   if (passwordInput.value === '') {
     document.querySelector('.giveMePassword').classList.remove('hidden');
-    document.querySelector('#password').classList.add('inputProblem');
+    document.querySelector('#password').classList.add('inputError');
     return false;
   }
   return true;

--- a/password.js
+++ b/password.js
@@ -4,13 +4,13 @@ export const passwordErrorMessage = document.querySelector(
   '.passwordErrorMessage'
 );
 
-function loginPassErrorReset() {
+function resetLoginPassError() {
   passwordErrorMessage.classList.add('hidden');
   document.querySelector('#password').classList.remove('inputError');
 } /* 로그인 - 비밀번호 오류 메시지를 초기화 하는 함수 */
 
-export const passwordPls = function (e) {
-  loginPassErrorReset();
+export const checkPassword = function (e) {
+  resetLoginPassError();
   if (passwordInput.value === '') {
     passwordErrorMessage.classList.remove('hidden');
     passwordErrorMessage.textContent = '비밀번호를 입력해 주세요.';
@@ -20,7 +20,7 @@ export const passwordPls = function (e) {
   return true;
 }; /* 비밀번호 입력하지 않으면 반응하는 함수 */
 
-export const passHideShow = function () {
+export const hideShowpassword = function () {
   passEyeButton.firstElementChild.classList.toggle('hidden');
   passEyeButton.lastElementChild.classList.toggle('hidden');
   if (passwordInput.type === 'password') {

--- a/signin.html
+++ b/signin.html
@@ -32,7 +32,9 @@
           <div class="emailContainer">
             <label for="email">이메일</label>
             <input id="email" name="email" type="email" />
-            <div class="hidden caution giveMeEmail">이메일을 입력해주세요.</div>
+            <div class="hidden caution emailErrorMessage">
+              이메일을 입력해주세요.
+            </div>
             <div class="hidden caution notEmail">
               올바른 이메일 주소가 아닙니다.
             </div>
@@ -51,7 +53,7 @@
                 />
               </button>
             </div>
-            <div class="hidden caution giveMePassword">
+            <div class="hidden caution passwordErrorMessage">
               비밀번호를 입력해 주세요.
             </div>
             <div class="hidden caution checkPassword">

--- a/signin.html
+++ b/signin.html
@@ -32,13 +32,7 @@
           <div class="emailContainer">
             <label for="email">이메일</label>
             <input id="email" name="email" type="email" />
-            <div class="hidden caution emailErrorMessage">
-              이메일을 입력해주세요.
-            </div>
-            <div class="hidden caution notEmail">
-              올바른 이메일 주소가 아닙니다.
-            </div>
-            <div class="hidden caution checkEmail">이메일을 확인해 주세요.</div>
+            <div class="hidden caution emailErrorMessage"></div>
           </div>
           <div class="passwordContainer">
             <label for="password">비밀번호</label>
@@ -53,12 +47,7 @@
                 />
               </button>
             </div>
-            <div class="hidden caution passwordErrorMessage">
-              비밀번호를 입력해 주세요.
-            </div>
-            <div class="hidden caution checkPassword">
-              비밀번호를 확인해 주세요.
-            </div>
+            <div class="hidden caution passwordErrorMessage"></div>
           </div>
           <button type="submit" class="signbutton">로그인</button>
         </form>

--- a/signin.js
+++ b/signin.js
@@ -6,10 +6,9 @@ import {
   hideShowpassword,
   passwordErrorMessage,
 } from './password.js';
+import { CORRECT_EMAIL, CORRECT_PASSWORD } from './usersData.js';
 
 const signinButton = document.querySelector('.signbutton');
-const CORRECT_EMAIL = 'test@codeit.com';
-const CORRECT_PASSWORD = 'codeit101';
 
 const checkUser = function () {
   if (

--- a/signin.js
+++ b/signin.js
@@ -1,23 +1,28 @@
-import { emailInput, emailPls } from './idEmail.js';
+import { emailInput, emailPls, emailErrorMessage } from './idEmail.js';
 import {
   passwordInput,
   passEyeButton,
   passwordPls,
   passHideShow,
+  passwordErrorMessage,
 } from './password.js';
 
 const signButton = document.querySelector('.signbutton');
+const correctEmail = 'test@codeit.com';
+const correctPassword = 'codeit101';
 
 const userCheck = function () {
   if (
-    emailInput.value === 'test@codeit.com' &&
-    passwordInput.value === 'codeit101'
+    emailInput.value === correctEmail &&
+    passwordInput.value === correctPassword
   ) {
     location.href = './folder';
   } else {
-    document.querySelector('.checkPassword').classList.remove('hidden');
+    passwordErrorMessage.classList.remove('hidden');
+    passwordErrorMessage.textContent = '비밀번호를 확인해주세요.';
     passwordInput.classList.add('inputError');
-    document.querySelector('.checkEmail').classList.remove('hidden');
+    emailErrorMessage.classList.remove('hidden');
+    emailErrorMessage.textContent = '이메일을 확인해주세요.';
     emailInput.classList.add('inputError');
   }
 }; // 로그인 정보 확인용 함수

--- a/signin.js
+++ b/signin.js
@@ -16,9 +16,9 @@ const userCheck = function () {
     location.href = './folder';
   } else {
     document.querySelector('.checkPassword').classList.remove('hidden');
-    passwordInput.classList.add('inputProblem');
+    passwordInput.classList.add('inputError');
     document.querySelector('.checkEmail').classList.remove('hidden');
-    emailInput.classList.add('inputProblem');
+    emailInput.classList.add('inputError');
   }
 }; // 로그인 정보 확인용 함수
 

--- a/signin.js
+++ b/signin.js
@@ -7,7 +7,7 @@ import {
   passwordErrorMessage,
 } from './password.js';
 
-const signupButton = document.querySelector('.signbutton');
+const signinButton = document.querySelector('.signbutton');
 const CORRECT_EMAIL = 'test@codeit.com';
 const CORRECT_PASSWORD = 'codeit101';
 
@@ -43,4 +43,4 @@ const checkLogin = function (e) {
 emailInput.addEventListener('focusout', checkEmail);
 passwordInput.addEventListener('focusout', checkPassword);
 passEyeButton.addEventListener('click', hideShowpassword);
-signupButton.addEventListener('click', checkLogin);
+signinButton.addEventListener('click', checkLogin);

--- a/signin.js
+++ b/signin.js
@@ -1,20 +1,20 @@
-import { emailInput, emailPls, emailErrorMessage } from './idEmail.js';
+import { emailInput, checkEmail, emailErrorMessage } from './idEmail.js';
 import {
   passwordInput,
   passEyeButton,
-  passwordPls,
-  passHideShow,
+  checkPassword,
+  hideShowpassword,
   passwordErrorMessage,
 } from './password.js';
 
-const signButton = document.querySelector('.signbutton');
-const correctEmail = 'test@codeit.com';
-const correctPassword = 'codeit101';
+const signupButton = document.querySelector('.signbutton');
+const CORRECT_EMAIL = 'test@codeit.com';
+const CORRECT_PASSWORD = 'codeit101';
 
-const userCheck = function () {
+const checkUser = function () {
   if (
-    emailInput.value === correctEmail &&
-    passwordInput.value === correctPassword
+    emailInput.value === CORRECT_EMAIL &&
+    passwordInput.value === CORRECT_PASSWORD
   ) {
     location.href = './folder';
   } else {
@@ -27,20 +27,20 @@ const userCheck = function () {
   }
 }; // 로그인 정보 확인용 함수
 
-const loginCheck = function (e) {
+const checkLogin = function (e) {
   e.preventDefault();
-  if (emailPls() === false) {
-    emailPls();
+  if (checkEmail() === false) {
+    checkEmail();
     emailInput.focus();
-  } else if (passwordPls() === false) {
-    passwordPls();
+  } else if (checkPassword() === false) {
+    checkPassword();
     passwordInput.focus();
   } else {
-    userCheck();
+    checkUser();
   }
 }; //로그인할 때 양식 및 정보 확인하는 함수
 
-emailInput.addEventListener('focusout', emailPls);
-passwordInput.addEventListener('focusout', passwordPls);
-passEyeButton.addEventListener('click', passHideShow);
-signButton.addEventListener('click', loginCheck);
+emailInput.addEventListener('focusout', checkEmail);
+passwordInput.addEventListener('focusout', checkPassword);
+passEyeButton.addEventListener('click', hideShowpassword);
+signupButton.addEventListener('click', checkLogin);

--- a/signup.html
+++ b/signup.html
@@ -32,18 +32,12 @@
           <div class="emailContainer">
             <label for="email">이메일</label>
             <input id="email" type="email" />
-            <div class="hidden caution giveMeEmail">이메일을 입력해주세요.</div>
-            <div class="hidden caution notEmail">
-              올바른 이메일 주소가 아닙니다.
-            </div>
-            <div class="hidden caution existEmail">
-              이미 사용 중인 이메일입니다.
-            </div>
+            <div class="hidden caution emailErrorMessage"></div>
           </div>
           <div class="passwordContainer">
             <label for="password">비밀번호</label>
             <div class="inputEye">
-              <input id="password" type="password" />
+              <input id="password" name="password" type="password" />
               <button type="button" class="passEye">
                 <img src="landing/eye-off.svg" alt="비밀번호 숨김 상태" />
                 <img
@@ -52,12 +46,7 @@
                   alt="비밀번호 보임 상태"
                 />
               </button>
-              <div class="hidden caution giveMePassword">
-                비밀번호를 입력해 주세요.
-              </div>
-              <div class="hidden caution incorrectPassword">
-                비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.
-              </div>
+              <div class="hidden caution passwordErrorMessage"></div>
             </div>
           </div>
           <div class="passwordcheckContainer">
@@ -73,9 +62,7 @@
                 />
               </button>
             </div>
-            <div class="hidden caution diffPassword">
-              비밀번호가 일치하지 않아요.
-            </div>
+            <div class="hidden caution passwordcheckErrorMessage"></div>
           </div>
           <button type="submit" class="signbutton">회원가입</button>
         </form>
@@ -102,6 +89,6 @@
         </div>
       </div>
     </main>
-    <script src="signup.js"></script>
+    <script type="module" src="signup.js"></script>
   </body>
 </html>

--- a/signup.js
+++ b/signup.js
@@ -1,96 +1,72 @@
-const emailInput = document.querySelector('#email');
-const passwordInput = document.querySelector('#password');
-const passCheckInput = document.querySelector('#passwordcheck');
-const passEyeButton = document.querySelector('.passEye');
-const checkEyeButton = document.querySelector('.passCheckEye');
-const signButton = document.querySelector('.signbutton');
+import { emailInput, checkEmail, emailErrorMessage } from './idEmail.js';
+import {
+  passwordInput,
+  passwordCheckInput,
+  passEyeButton,
+  passCheckEyeButton,
+  hideShowpassword,
+  resetLoginPassError,
+  passwordErrorMessage,
+  passwordcheckErrorMessage,
+} from './password.js';
+import { CORRECT_EMAIL } from './usersData.js';
 
-let A = 0; /* 비밀번호 보이기/숨기기 함수용 변수, 좋은 변수명 구함11 */
-let B = 0; /* 비밀번호 확인 보이기/숨기기 함수용 변수, 좋은 변수명 구함22 */
+const signupButton = document.querySelector('.signbutton');
 
-function loginEmailErrorReset() {
-  document.querySelector('.giveMeEmail').classList.add('hidden');
-  document.querySelector('.notEmail').classList.add('hidden');
-  document.querySelector('.checkEmail').classList.add('hidden');
-  document.querySelector('#email').classList.remove('inputProblem');
-} /* 로그인 - 이메일 오류 메시지를 초기화 하는 함수  */
-
-function loginPassErrorReset() {
-  document.querySelector('.checkPassword').classList.add('hidden');
-  document.querySelector('.giveMePassword').classList.add('hidden');
-  document.querySelector('#password').classList.remove('inputProblem');
-} /* 로그인 - 비밀번호 오류 메시지를 초기화 하는 함수 */
-
-function isEmail(email) {
-  const A = email.indexOf('@');
-  if (A === -1) {
+const checkSignupEmail = function () {
+  if (emailInput.value === CORRECT_EMAIL) {
+    emailErrorMessage.classList.remove('hidden');
+    emailErrorMessage.textContent = '이미 사용중인 이메일입니다.';
+    emailInput.classList.add('inputError');
     return false;
-  } else if (email.slice(0, A).length === 0) {
-    return false;
-  } else if (email.slice(A + 1).length === 0) {
+  }
+  checkEmail();
+  return checkEmail();
+};
+
+const checkSignupPassword = function () {
+  resetLoginPassError();
+  const englishOnly = /^[a-zA-z]+$/;
+  const numberOnly = /^[\d]+$/;
+  if (
+    passwordInput.value.length < 8 ||
+    englishOnly.test(passwordInput.value) ||
+    numberOnly.test(passwordInput.value)
+  ) {
+    passwordErrorMessage.classList.remove('hidden');
+    passwordErrorMessage.textContent =
+      '비밀번호는 영문, 숫자 조합 8자 이상 입력해주세요.';
+    passwordInput.classList.add('inputError');
     return false;
   }
   return true;
-} /* 이메일이 맞으면 true를 뱉는 함수*/
+};
 
-const emailPls = function (e) {
-  loginEmailErrorReset();
-  if (emailInput.value === '') {
-    document.querySelector('.giveMeEmail').classList.remove('hidden');
-    document.querySelector('#email').classList.add('inputProblem');
-  } else if (isEmail(emailInput.value) === false) {
-    document.querySelector('.notEmail').classList.remove('hidden');
-    document.querySelector('#email').classList.add('inputProblem');
+const checkPasswordOneMore = function () {
+  passwordcheckErrorMessage.classList.add('hidden');
+  passwordCheckInput.classList.remove('inputError');
+  if (passwordInput.value !== passwordCheckInput.value) {
+    passwordcheckErrorMessage.classList.remove('hidden');
+    passwordcheckErrorMessage.textContent = '비밀번호가 일치하지 않아요.';
+    passwordCheckInput.classList.add('inputError');
+    return false;
   }
-}; /* 이메일을 입력하지 않거나 이메일 주소로 입력하지 않을 때 반응하는 함수 */
+  return true;
+};
 
-const passwordPls = function (e) {
-  loginPassErrorReset();
-  if (passwordInput.value === '') {
-    document.querySelector('.giveMePassword').classList.remove('hidden');
-    document.querySelector('#password').classList.add('inputProblem');
-  }
-}; /* 비밀번호 입력하지 않으면 반응하는 함수 */
-
-emailInput.addEventListener('focusout', emailPls);
-passwordInput.addEventListener('focusout', passwordPls);
-
-passEyeButton.onclick = function () {
-  passEyeButton.firstElementChild.classList.toggle('hidden');
-  passEyeButton.lastElementChild.classList.toggle('hidden');
-  A = A + 1;
-  if (A % 2) {
-    passwordInput.type = 'text';
-  } else {
-    passwordInput.type = 'password';
-  }
-}; /* 비밀번호 칸에서 눈을 눌러 비밀번호 보이기와 숨기기를 하게 하는 함수이자 이벤트 */
-
-signButton.onclick = function (e) {
+const checkSignup = function (e) {
   e.preventDefault();
-  loginEmailErrorReset();
-  loginPassErrorReset();
-  if (
-    emailInput.value === 'test@codeit.com' &&
-    passwordInput.value === 'codeit101'
-  ) {
+  checkSignupEmail();
+  checkSignupPassword();
+  checkPasswordOneMore();
+  if (checkSignupEmail() && checkSignupPassword() && checkPasswordOneMore()) {
     location.href = './folder';
-  } else {
-    document.querySelector('.checkPassword').classList.remove('hidden');
-    document.querySelector('#password').classList.add('inputProblem');
-    document.querySelector('.checkEmail').classList.remove('hidden');
-    document.querySelector('#email').classList.add('inputProblem');
-    document.querySelector('#email').focus();
   }
 };
 
-checkEyeButton.onclick = function () {
-  checkEyeButton.firstElementChild.classList.toggle('hidden');
-  checkEyeButton.lastElementChild.classList.toggle('hidden');
-  B = B + 1;
-  if (B % 2) {
-    passCheckInput.type = 'text';
-  } else {
-    passCheckInput.type = 'password';
-  }
-}; /* 비밀번호 확인 칸에서 눈을 눌러 비밀번호 보이기와 숨기기를 하게 하는 함수이자 이벤트 */
+emailInput.addEventListener('focusout', checkSignupEmail);
+passwordInput.addEventListener('focusout', checkSignupPassword);
+passwordCheckInput.addEventListener('focusout', checkPasswordOneMore);
+passEyeButton.addEventListener('click', hideShowpassword);
+passCheckEyeButton.addEventListener('click', hideShowpassword);
+signupButton.addEventListener('click', checkSignup);

--- a/usersData.js
+++ b/usersData.js
@@ -1,0 +1,2 @@
+export const CORRECT_EMAIL = 'test@codeit.com';
+export const CORRECT_PASSWORD = 'codeit101';


### PR DESCRIPTION
## 요구사항

### 기본

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] 이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] 로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

-
- 모듈화 및 함수 이름 변경

## 스크린샷

![image](이미지url)

## 멘토에게

-
-
