### PR TITLE
[조혜진] Week5

### DIFF
--- a/src/sign/sign.css
+++ b/src/sign/sign.css
@@ -5,7 +5,7 @@ body {
     display: flex;
     justify-content: center;
     background-color: var(--gray5);
-    padding-top: 150px;
+    padding-top: 180px;
 }
 
 /* m a i n */
@@ -94,8 +94,7 @@ main {
 
 .eye_button {
     position: absolute;
-    top: 50%;
-    transform: translateY(-50%);
+    top: 48px;
     right: 15px; 
     width: 16px;
     height: 16px;

--- a/src/sign/signin.html
+++ b/src/sign/signin.html
@@ -19,15 +19,15 @@
         <div class="input_container">
             <div class="input_box">
                 <label for="email">이메일</label>
-                <input type="email" id="email" placeholder="이메일을 입력하세요">
-                <p class="error_msg" id="email_error">이메일을 입력해 주세요.</p>
+                <input type="email" id="email" placeholder="이메일을 입력하세요" autofocus>
+                <p class="error_msg" id="email_error"></p>
             </div>
         </div>
         <div class="input_container"> 
             <div class="input_box">
                 <label for="password">비밀번호</label>
                 <input type="password" id="password" placeholder="비밀번호를 입력하세요">
-                <p class="error_msg" id="password_error">비밀번호를 입력해 주세요.</p>
+                <p class="error_msg" id="password_error"></p>
                 <button class="eye_button" id="eye_toggle" type="button"></button>
             </div>
         </div>
@@ -52,6 +52,6 @@
             </div>
         </div>
     </main>
-    <script src="signin.js"></script>
+    <script type="module" src="signin.js"></script>
 </body>
 </html>

--- a/src/sign/signin.js
+++ b/src/sign/signin.js
@@ -1,3 +1,8 @@
+const TEST_USER = {
+    email: "test@codeit.com",
+    password: "codeit101",
+};
+
 // 이메일 검사
 function validateEmail(email) {
     const validate = /\S+@\S+\.\S+/;
@@ -12,7 +17,7 @@ function validateInput(inputValue, errorElement, errorMessage) {
         return false;
     }
     
-    errorElement.textContent = '　';
+    errorElement.textContent = '';
     return true;
 }
 
@@ -46,15 +51,12 @@ document.addEventListener('keydown', function(event) {
     }
 });
 
-const TEST_EMAIL = 'test@codeit.com'
-const TEST_PWD = 'codeit101'
-
 function submitUser() {
     const email = document.getElementById('email').value.trim();
     const password = document.getElementById('password').value.trim();
 
     // 이메일 및 비밀번호 유효성 검사
-    if (email === TEST_EMAIL && password === TEST_PWD) {
+    if (email === TEST_USER.email && password === TEST_USER.password) {
         window.location.href = '/folder'; // 로그인 성공 시 이동
     } else {
         // 로그인 실패 시 에러 메시지 표시

--- a/src/sign/signin.js
+++ b/src/sign/signin.js
@@ -4,15 +4,29 @@ function validateEmail(email) {
     return validate.test(email);
 }
 
+// 이메일 및 비밀번호 검사 함수
+function validateInput(inputValue, errorElement, errorMessage) {
+    const trimmedValue = inputValue.trim();
+    if (!trimmedValue) {
+        errorElement.textContent = errorMessage;
+        return false;
+    }
+    
+    errorElement.textContent = '　';
+    return true;
+}
+
+// 이메일 검사
 document.getElementById('email').addEventListener('focusout', function() {
     const email = this.value.trim();
     const emailError = document.getElementById('email_error');
-    if (email === '') {
-        emailError.textContent = '이메일을 입력해 주세요.';
-    } else if (!validateEmail(email)) {
+    if (!validateInput(email, emailError, '이메일을 입력해 주세요.')) {
+        return;
+    }
+    
+    if (!validateEmail(email)) {
         emailError.textContent = '올바른 이메일 주소가 아닙니다.';
-    } else {
-        emailError.textContent = '　';
+        return;
     }
 });
 
@@ -20,11 +34,7 @@ document.getElementById('email').addEventListener('focusout', function() {
 document.getElementById('password').addEventListener('focusout', function() {
     const password = this.value.trim();
     const passwordError = document.getElementById('password_error');
-    if (password === '') {
-        passwordError.textContent = '비밀번호를 입력해 주세요.';
-    } else {
-        passwordError.textContent = '　';
-    }
+    validateInput(password, passwordError, '비밀번호를 입력해 주세요.');
 });
 
 // submit
@@ -36,12 +46,15 @@ document.addEventListener('keydown', function(event) {
     }
 });
 
+const TEST_EMAIL = 'test@codeit.com'
+const TEST_PWD = 'codeit101'
+
 function submitUser() {
     const email = document.getElementById('email').value.trim();
     const password = document.getElementById('password').value.trim();
 
     // 이메일 및 비밀번호 유효성 검사
-    if (email === 'test@codeit.com' && password === 'codeit101') {
+    if (email === TEST_EMAIL && password === TEST_PWD) {
         window.location.href = '/folder'; // 로그인 성공 시 이동
     } else {
         // 로그인 실패 시 에러 메시지 표시
@@ -67,5 +80,3 @@ eyeToggle.addEventListener('click', function() {
         eyeToggle.classList.remove('on');
     }
 });
-
-

--- a/src/sign/signup.html
+++ b/src/sign/signup.html
@@ -35,7 +35,7 @@
             <div class="input_box">
                 <label for="password">비밀번호 확인</label>
                 <input type="password" id="passwordCheck" placeholder="비밀번호를 입력하세요">
-                <p class="error_msg" id="passwordCheck_error">비밀번호를 다시 입력해 주세요.</p>
+                <p class="error_msg" id="passwordCheck_error"></p>
                 <button class="eye_button" id="eye_toggle2" type="button"></button>
             </div>
         </div>

--- a/src/sign/signup.html
+++ b/src/sign/signup.html
@@ -19,15 +19,15 @@
         <div class="input_container">
             <div class="input_box">
                 <label for="email">이메일</label>
-                <input type="email" id="email" placeholder="이메일을 입력하세요">
-                <p class="error_msg" id="email_error">이메일을 입력해 주세요.</p>
+                <input type="email" id="email" placeholder="이메일을 입력하세요" autofocus>
+                <p class="error_msg" id="email_error"></p>
             </div>
         </div>
         <div class="input_container">
             <div class="input_box">
                 <label for="password">비밀번호</label>
                 <input type="password" id="password" placeholder="비밀번호를 입력하세요">
-                <p class="error_msg" id="password_error">비밀번호를 입력해 주세요.</p>
+                <p class="error_msg" id="password_error"></p>
                 <button class="eye_button" id="eye_toggle" type="button"></button>
             </div>
         </div>
@@ -60,6 +60,6 @@
             </div>
         </div>
     </main>
-    <script src="signup.js"></script>
+    <script type="module" src="signup.js"></script>
 </body>
 </html>

--- a/src/sign/signup.js
+++ b/src/sign/signup.js
@@ -24,13 +24,13 @@ function validateInput(inputValue, errorElement, errorMessage) {
 // 이메일 검사
 document.getElementById('email').addEventListener('focusout', function() {
     const email = this.value.trim();
-    const emailError = document.getElementById('email_error');
-    if (!validateInput(email, emailError, '이메일을 입력해 주세요.')) {
+    const email_error = document.getElementById('email_error');
+    if (!validateInput(email, email_error, '이메일을 입력해 주세요.')) {        
         return;
     }
     
     if (!validateEmail(email)) {
-        emailError.textContent = '올바른 이메일 주소가 아닙니다.';
+        email_error.textContent = '올바른 이메일 주소가 아닙니다.';
         return;
     }
 });
@@ -53,7 +53,6 @@ document.getElementById('password').addEventListener('focusout', function() {
         password_error.textContent = '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.';
         return;
     }
-
 });
 
 // 비밀번호 확인 검사
@@ -77,17 +76,17 @@ const inputs = [
 ];
 
 inputs.forEach(input => {
-    const eyeToggle = document.getElementById(input.toggleId);
-    const passwordInput = document.getElementById(input.inputId);
+    const eye_toggle = document.getElementById(input.toggleId);
+    const password_input = document.getElementById(input.inputId);
 
     eyeToggle.addEventListener('click', function() {
-        const type = passwordInput.getAttribute('type') === 'password' ? 'text' : 'password';
-        passwordInput.setAttribute('type', type);
+        const type = password_input.getAttribute('type') === 'password' ? 'text' : 'password';
+        password_input.setAttribute('type', type);
 
         if (type === 'text') {
-            eyeToggle.classList.add('on');
+            eye_toggle.classList.add('on');
         } else {
-            eyeToggle.classList.remove('on');
+            eye_toggle.classList.remove('on');
         }
     });
 });
@@ -103,12 +102,30 @@ document.addEventListener('keydown', function(event) {
 
 function submitUser() {
     const email = document.getElementById('email').value.trim();
-    const emailError = document.getElementById('email_error');
+    const email_error = document.getElementById('email_error');
 
     // 이메일 및 비밀번호 유효성 검사
-    if (email === TEST_USER.email) {
-        emailError.textContent = '이미 사용 중인 이메일입니다.';
+    if (!validateEmail(email)) {
+        email_error.textContent = '올바른 이메일 주소가 아닙니다.';
+        return; 
+    } else if (email === TEST_USER.email) {
+        email_error.textContent = '이미 사용 중인 이메일입니다.';
         return;
     } 
+    
+    const password = document.getElementById('password').value.trim();
+    const password_error = document.getElementById('password_error');
+    if (!validatePassword(password)) {
+        password_error.textContent = '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.';
+        return;
+    }
+
+    const passwordCheck = document.getElementById('passwordCheck').value.trim();
+    const passwordCheck_error = document.getElementById('passwordCheck_error');
+    if (passwordCheck !== password) {
+        passwordCheck_error.textContent = '비밀번호가 다릅니다.';
+        return; 
+    }
+
     window.location.href = '/folder'; // 회원가입 성공 시 이동    
 }

--- a/src/sign/signup.js
+++ b/src/sign/signup.js
@@ -1,3 +1,8 @@
+const TEST_USER = {
+    email: "test@codeit.com",
+    password: "codeit101",
+};
+
 // 이메일 검사
 function validateEmail(email) {
     const validate = /\S+@\S+\.\S+/;
@@ -12,7 +17,7 @@ function validateInput(inputValue, errorElement, errorMessage) {
         return false;
     }
     
-    errorElement.textContent = '　';
+    errorElement.textContent = '';
     return true;
 }
 
@@ -31,46 +36,79 @@ document.getElementById('email').addEventListener('focusout', function() {
 });
 
 // 비밀번호 검사
+function validatePassword(password){
+    const validate = /^.*(?=.{8,20})(?=.*[0-9])(?=.*[a-zA-Z]).*$/;
+    return validate.test(password);
+}
+
+// 비밀번호 검사
 document.getElementById('password').addEventListener('focusout', function() {
     const password = this.value.trim();
-    const passwordError = document.getElementById('password_error');
-    validateInput(password, passwordError, '비밀번호를 입력해 주세요.');
+    const password_error = document.getElementById('password_error');
+    if(!validateInput(password, password_error, '비밀번호를 입력해 주세요.')) {
+        return;
+    }
+
+    if(!validatePassword(password)) {
+        password_error.textContent = '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.';
+        return;
+    }
+
 });
 
 // 비밀번호 확인 검사
 document.getElementById('passwordCheck').addEventListener('focusout', function() {
-    const password = this.value.trim();
+    const passwordCheck = this.value.trim();
+    const password = document.getElementById('password').trim();
     const passwordCheck_error = document.getElementById('passwordCheck_error');
-    validateInput(password, passwordCheck_error, '비밀번호를 입력해 주세요.');
+    if(!validateInput(passwordCheck, passwordCheck_error, '비밀번호를 확인해 주세요.')){
+        return;
+    }
+    if(passwordCheck !== password) {
+        passwordCheck_error.textContent = '비밀번호가 다릅니다.';
+        return;
+    }
 });
 
 // password eye toggle
-const eyeToggle = document.getElementById('eye_toggle');
-const passwordInput = document.getElementById('password');
+const inputs = [
+    { inputId: 'password', toggleId: 'eye_toggle' },
+    { inputId: 'passwordCheck', toggleId: 'eye_toggle2' }
+];
 
-eyeToggle.addEventListener('click', function() {
-    const type = passwordInput.getAttribute('type') === 'password' ? 'text' : 'password';
-    passwordInput.setAttribute('type', type);
+inputs.forEach(input => {
+    const eyeToggle = document.getElementById(input.toggleId);
+    const passwordInput = document.getElementById(input.inputId);
 
-    if (type === 'text') {
-        eyeToggle.classList.add('on');
-    } else {
-        eyeToggle.classList.remove('on');
+    eyeToggle.addEventListener('click', function() {
+        const type = passwordInput.getAttribute('type') === 'password' ? 'text' : 'password';
+        passwordInput.setAttribute('type', type);
+
+        if (type === 'text') {
+            eyeToggle.classList.add('on');
+        } else {
+            eyeToggle.classList.remove('on');
+        }
+    });
+});
+
+// submit
+document.querySelector('.submit_btn').addEventListener('click', submitUser);
+
+document.addEventListener('keydown', function(event) {
+    if (event.key === 'Enter') {
+        submitUser();
     }
 });
 
-// password check eye toggle
-const eyeToggle2 = document.getElementById('eye_toggle2');
-const passwordCheckInput = document.getElementById('passwordCheck');
+function submitUser() {
+    const email = document.getElementById('email').value.trim();
+    const emailError = document.getElementById('email_error');
 
-eyeToggle2.addEventListener('click', function() {
-    const type = passwordCheckInput.getAttribute('type') === 'password' ? 'text' : 'password';
-    passwordCheckInput.setAttribute('type', type);
-
-    if (type === 'text') {
-        eyeToggle2.classList.add('on');
-    } else {
-        eyeToggle2.classList.remove('on');
-    }
-});
-
+    // 이메일 및 비밀번호 유효성 검사
+    if (email === TEST_USER.email) {
+        emailError.textContent = '이미 사용 중인 이메일입니다.';
+        return;
+    } 
+    window.location.href = '/folder'; // 회원가입 성공 시 이동    
+}

--- a/src/sign/signup.js
+++ b/src/sign/signup.js
@@ -4,15 +4,29 @@ function validateEmail(email) {
     return validate.test(email);
 }
 
+// 이메일 및 비밀번호 검사 함수
+function validateInput(inputValue, errorElement, errorMessage) {
+    const trimmedValue = inputValue.trim();
+    if (!trimmedValue) {
+        errorElement.textContent = errorMessage;
+        return false;
+    }
+    
+    errorElement.textContent = '　';
+    return true;
+}
+
+// 이메일 검사
 document.getElementById('email').addEventListener('focusout', function() {
     const email = this.value.trim();
     const emailError = document.getElementById('email_error');
-    if (email === '') {
-        emailError.textContent = '이메일을 입력해 주세요.';
-    } else if (!validateEmail(email)) {
+    if (!validateInput(email, emailError, '이메일을 입력해 주세요.')) {
+        return;
+    }
+    
+    if (!validateEmail(email)) {
         emailError.textContent = '올바른 이메일 주소가 아닙니다.';
-    } else {
-        emailError.textContent = '　';
+        return;
     }
 });
 
@@ -20,22 +34,14 @@ document.getElementById('email').addEventListener('focusout', function() {
 document.getElementById('password').addEventListener('focusout', function() {
     const password = this.value.trim();
     const passwordError = document.getElementById('password_error');
-    if (password === '') {
-        passwordError.textContent = '비밀번호를 입력해 주세요.';
-    } else {
-        passwordError.textContent = '　';
-    }
+    validateInput(password, passwordError, '비밀번호를 입력해 주세요.');
 });
 
 // 비밀번호 확인 검사
 document.getElementById('passwordCheck').addEventListener('focusout', function() {
     const password = this.value.trim();
-    const passwordCheckError = document.getElementById('passwordCheck_error');
-    if (password === '') {
-        passwordCheckError.textContent = '비밀번호를 다시 입력해 주세요.';
-    } else {
-        passwordCheckError.textContent = '　';
-    }
+    const passwordCheck_error = document.getElementById('passwordCheck_error');
+    validateInput(password, passwordCheck_error, '비밀번호를 입력해 주세요.');
 });
 
 // password eye toggle


### PR DESCRIPTION
## 요구사항

### 기본

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] 이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] 이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [ ] 로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- signup.js focus out error message
- 회원가입

## 스크린샷

![image](https://github.com/codeit-bootcamp-frontend/5-Weekly-Mission/assets/57613101/1d3525a1-e213-4f38-89b9-2554a680b6f9)

## 멘토에게

- invalid 적용이 어렵습니다.. 에러메시지가 떠도 테두리가 빨간색으로 변하지 않아요.. required를 넣으면 focus가 안되어도 빨간색으로 떠서 어떻게 해결해야 할 지 모르겠습니다.

