### PR TITLE
[김미소]Week5

### DIFF
--- a/js/module/join/addErrorMessage.js
+++ b/js/module/join/addErrorMessage.js
@@ -1,0 +1,5 @@
+function addInputMessage (target, massage) { // error massage add
+  const parent = target.closest('.form__box');
+  parent.classList.add('error');
+  parent.querySelector('.error__text').innerText = massage;
+}

--- a/js/module/join/join.js
+++ b/js/module/join/join.js
@@ -1,0 +1,59 @@
+function emailErrorMessage (email) { // 이메일 에러 메세지
+  switch (validateEmail(email)) {
+    case 'emailEmpty':
+      addInputMessage(email, '이메일을 입력해 주세요.');
+      break;
+    case 'emailError':
+      addInputMessage(email, '올바른 이메일 주소가 아닙니다.');
+      break;
+    case 'emailSameName':
+      addInputMessage(email, '이미 사용 중인 이메일입니다.');
+      break;
+    case 'submitError':
+      addInputMessage(email, '이메일을 확인해 주세요.');
+      break;
+    default:
+      removeInputMessage(email);
+      break;
+  }
+}
+
+function passwordErrorMessage (password) { // 비밀번호 에러 메세지
+  if(password === undefined) {
+    return  false;
+  }
+  switch (validatePassword(password)) {
+    case 'pwEmpty':
+      addInputMessage(password, '비밀번호를 입력해 주세요.');
+      break;
+    case 'pwLenError':
+      addInputMessage(password, '비밀번호는 영어, 숫자 8자 이상 입력해 주세요.');
+      break;
+    case 'submitError':
+      addInputMessage(email, '이메일을 확인해 주세요.');
+      break;
+    default:
+      removeInputMessage(password);
+      break;
+  }
+}
+
+function passwordConfirmErrorMessage (password, passwordConfirm) {
+  if(passwordConfirm === undefined) {
+    return  false;
+  }
+  switch (validatePasswordConfirm(password, passwordConfirm)) {
+    case 'pwConfirmEmpty':
+      addInputMessage(passwordConfirm, '비밀번호 확인을 입력해 주세요.');
+      break;
+    case 'pwConfirmLenError':
+      addInputMessage(passwordConfirm, '비밀번호는 영어, 숫자 8자 이상 입력해 주세요.');
+      break;
+    case 'pwConfirmError':
+      addInputMessage(passwordConfirm, '비밀번호가 다릅니다.');  
+      break;
+    default:
+      removeInputMessage(passwordConfirm);
+      break;
+  }
+}

--- a/js/module/join/removeErrorMassage.js
+++ b/js/module/join/removeErrorMassage.js
@@ -1,0 +1,5 @@
+function removeInputMessage (target) { // error massage remove
+  const parent = target.closest('.form__box');
+  parent.classList.remove('error');
+  parent.querySelector('.error__text').innerText = ''
+}

--- a/js/module/join/validation.js
+++ b/js/module/join/validation.js
@@ -1,0 +1,67 @@
+const users = [
+  { email:'test@codeit.com', pw:'codeit101' },
+]
+
+function validateEmail (email) { // 이메일
+  if(email === undefined) {
+    return ;
+  }
+  const regex = new RegExp('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$');
+  const user = users.find(data => data.email === email.value.trim()) ?? '';
+
+  if (email.value.trim() === '') {
+    validateObject.email = false;
+    return 'emailEmpty'
+  } else if (!regex.test(email.value.trim())) {
+    validateObject.email = false;
+    return 'emailError'
+  } else if (user.email === email.value.trim()) {
+    if (email.id === 'signin__email') {
+      validateObject.email = true;
+      return ''
+    } else {
+      validateObject.email = false;
+      return 'emailSameName'
+    }
+  } else {
+    validateObject.email = true;
+    return ''
+  }
+}
+
+function validatePassword (passwrod) { // 비밀번호
+  if(passwrod === undefined) {
+    return ;
+  }
+  const regex = new RegExp('^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$');
+  if (passwrod.value.trim() === '') {
+    validateObject.password = false;
+    return 'pwEmpty'
+  } else if (!regex.test(passwrod.value.trim())) {
+    validateObject.password = false;
+    return 'pwLenError'
+  } else {
+    validateObject.password = true;
+    return ''
+  }
+}
+
+function validatePasswordConfirm (passwrod, passwordConfirm) { // 비밀번호 확인
+  if(passwrod === undefined) {
+    return ;
+  }
+  const regex = new RegExp('^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$');
+  if (passwordConfirm.value.trim() === '') {
+    validateObject.passwordConfirm = false;
+    return 'pwConfirmEmpty'
+  } else if (passwrod.value.trim() !== passwordConfirm.value.trim()) {
+    validateObject.passwordConfirm = false;
+    return 'pwConfirmError'
+  } else if (!regex.test(signupPassword.value.trim())) {
+    validateObject.passwordConfirm = false;
+    return 'pwConfirmLenError'
+  } else {
+    validateObject.passwordConfirm = true;
+    return ''
+  }
+}

--- a/js/signin.js
+++ b/js/signin.js
@@ -3,111 +3,45 @@ const signinFomeInput = document.querySelectorAll('.signin__wrap input');
 const signinEmail = document.querySelector('#signin__email');
 const signinPassword = document.querySelector('#signin__pw__input');
 const submitButton = document.querySelector('.signin__wrap .btn_signin');
+
 let validateObject = { // 활성화
   email:false,
   password:false,
 }; 
 
-const users = [
-  { email:'test@codeit.com', pw:'codeit101' },
-]
-
-function emailErrorMessage () { // 이메일 에러 메세지
-  switch (validateEmail()) {
-    case 'emailEmpty':
-      addInputMessage(signinEmail, '이메일을 입력해 주세요.');
-      break;
-    case 'emailError':
-      addInputMessage(signinEmail, '올바른 이메일 주소가 아닙니다.');
-      break;
-    default:
-      removeInputMessage(signinEmail);
-      break;
-  }
-}
-
-function passwordErrorMessage () { // 비밀번호 에러 메세지
-  switch (validatePassword()) {
-    case 'pwEmpty':
-      addInputMessage(signinPassword, '비밀번호를 입력해 주세요.');
-      break;
-    default:
-      removeInputMessage(signinPassword);
-      break;
-  }
-}
-
-function validateEmail () { // 이메일
-  const regex = new RegExp('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$');
-  if (signinEmail.value.trim() === '') {
-    validateObject.email = false;
-    return 'emailEmpty'
-  } else if (regex.test(signinEmail.value.trim())) {
-    validateObject.email = true;
-    return ''
-  } else {
-    validateObject.email = false;
-    return 'emailError'
-  }
-}
-
-function validatePassword () { // 비밀번호
-  if (signinPassword.value.trim() === '') {
-    validateObject.password = false;
-    return 'pwEmpty'
-  } else {
-    validateObject.password = true;
-    return ''
-  }
-}
-
-function addInputMessage (target, massage) { // error massage add
-  const parent = target.closest('.form__box');
-  parent.classList.add('error');
-  parent.querySelector('.error__text').innerText = massage;
-}
-
-function removeInputMessage(target) { // error massage remove
-  const parent = target.closest('.form__box');
-  parent.classList.remove('error');
-  parent.querySelector('.error__text').innerText = ''
-}
-
-function validateForm (e) { // form handler
-  e.preventDefault();
-  validateEmail();
-  validatePassword();
-  formActiveBtn();
-
-  const user = users.find(data => data.email === signinEmail.value.trim() && data.pw === signinPassword.value.trim() );
-  if (user) {
-    window.location.href='/folder.html';
-  } else if (users[0].email === signinEmail.value.trim()) {
-    addInputMessage(signinPassword,'비밀번호를 확인해 주세요.')
-  } else {
-    addInputMessage(signinEmail,'이메일을 확인해 주세요.')
-    addInputMessage(signinPassword,'비밀번호를 확인해 주세요.')
-  }
-}
-
 function focusOutInput (e) {
   const {target} = e;
   if (target.id === signinEmail.id) {
-    emailErrorMessage();
+    emailErrorMessage(signinEmail);
   };
 
   if (target.id === signinPassword.id) {
-    passwordErrorMessage();
+    passwordErrorMessage(signinPassword);
   };
   formActiveBtn();
 }
 
 function formActiveBtn () {
   const inputs = [validateObject.email,validateObject.password].every(data => data === true);
+  
   if (inputs) {
     submitButton.removeAttribute('disabled');
   } else {
     submitButton.setAttribute('disabled', 'disabled');
+  }
+}
+
+function validateForm (e) { // form handler
+  e.preventDefault();
+  formActiveBtn();
+
+  const user = users.find(data => data.email === signinEmail.value.trim() && data.pw === signinPassword.value.trim() );
+
+  if (user) {
+    window.location.href='/folder.html';
+  } else {
+    addInputMessage(signinEmail,'비밀번호를 확인해 주세요.')
+    addInputMessage(signinPassword,'비밀번호를 확인해 주세요.')
   }
 }
 

--- a/js/signup.js
+++ b/js/signup.js
@@ -11,6 +11,10 @@ let validateObject = { // 활성화
   passwordConfirm:false,
 }; 
 
+const users = [
+  { email:'test@codeit.com', pw:'codeit101' },
+]
+
 function emailErrorMessage () { // 이메일 에러 메세지
   switch (validateEmail()) {
     case 'emailEmpty':
@@ -18,6 +22,9 @@ function emailErrorMessage () { // 이메일 에러 메세지
       break;
     case 'emailError':
       addInputMessage(signupEmail, '올바른 이메일 주소가 아닙니다.');
+      break;
+    case 'emailSameName':
+      addInputMessage(signupEmail, '이미 사용 중인 이메일입니다.');
       break;
     default:
       removeInputMessage(signupEmail);
@@ -30,6 +37,9 @@ function passwordErrorMessage () { // 비밀번호 에러 메세지
     case 'pwEmpty':
       addInputMessage(signupPassword, '비밀번호를 입력해 주세요.');
       break;
+    case 'pwLenError':
+      addInputMessage(signupPassword, '비밀번호는 영어, 숫자 8자 이상 입력해 주세요.');
+      break;
     default:
       removeInputMessage(signupPassword);
       break;
@@ -40,6 +50,9 @@ function passwordConfirmErrorMessage () {
   switch (validatePasswordConfirm()) {
     case 'pwConfirmEmpty':
       addInputMessage(signupPasswordConfirm, '비밀번호 확인을 입력해 주세요.');
+      break;
+    case 'pwConfirmLenError':
+      addInputMessage(signupPasswordConfirm, '비밀번호는 영어, 숫자 8자 이상 입력해 주세요.');
       break;
     case 'pwConfirmError':
       addInputMessage(signupPasswordConfirm, '비밀번호가 다릅니다.');  
@@ -52,22 +65,30 @@ function passwordConfirmErrorMessage () {
 
 function validateEmail () { // 이메일
   const regex = new RegExp('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$');
+  const user = users.find(data => data.email === signupEmail.value.trim()) ?? '';
   if (signupEmail.value.trim() === '') {
     validateObject.email = false;
     return 'emailEmpty'
-  } else if (regex.test(signupEmail.value.trim())) {
-      validateObject.email = true;
-      return ''
-  } else {
+  } else if (!regex.test(signupEmail.value.trim())) {
     validateObject.email = false;
     return 'emailError'
+  } else if (user.email === signupEmail.value.trim()) {
+    validateObject.email = false;
+    return 'emailSameName'
+  } else {
+    validateObject.email = true;
+    return ''
   }
 }
 
 function validatePassword () { // 비밀번호
+  const regex = new RegExp('^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$');
   if (signupPassword.value.trim() === '') {
     validateObject.password = false;
     return 'pwEmpty'
+  } else if (!regex.test(signupPassword.value.trim())) {
+    validateObject.password = false;
+    return 'pwLenError'
   } else {
     validateObject.password = true;
     return ''
@@ -75,12 +96,16 @@ function validatePassword () { // 비밀번호
 }
 
 function validatePasswordConfirm () { // 비밀번호 확인
+  const regex = new RegExp('^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$');
   if (signupPasswordConfirm.value.trim() === '') {
     validateObject.passwordConfirm = false;
     return 'pwConfirmEmpty'
   } else if (signupPassword.value.trim() !== signupPasswordConfirm.value.trim()) {
     validateObject.passwordConfirm = false;
     return 'pwConfirmError'
+  } else if (!regex.test(signupPassword.value.trim())) {
+    validateObject.passwordConfirm = false;
+    return 'pwConfirmLenError'
   } else {
     validateObject.passwordConfirm = true;
     return ''

--- a/js/signup.js
+++ b/js/signup.js
@@ -11,137 +11,26 @@ let validateObject = { // 활성화
   passwordConfirm:false,
 }; 
 
-const users = [
-  { email:'test@codeit.com', pw:'codeit101' },
-]
-
-function emailErrorMessage () { // 이메일 에러 메세지
-  switch (validateEmail()) {
-    case 'emailEmpty':
-      addInputMessage(signupEmail, '이메일을 입력해 주세요.');
-      break;
-    case 'emailError':
-      addInputMessage(signupEmail, '올바른 이메일 주소가 아닙니다.');
-      break;
-    case 'emailSameName':
-      addInputMessage(signupEmail, '이미 사용 중인 이메일입니다.');
-      break;
-    default:
-      removeInputMessage(signupEmail);
-      break;
-  }
-}
-
-function passwordErrorMessage () { // 비밀번호 에러 메세지
-  switch (validatePassword()) {
-    case 'pwEmpty':
-      addInputMessage(signupPassword, '비밀번호를 입력해 주세요.');
-      break;
-    case 'pwLenError':
-      addInputMessage(signupPassword, '비밀번호는 영어, 숫자 8자 이상 입력해 주세요.');
-      break;
-    default:
-      removeInputMessage(signupPassword);
-      break;
-  }
-}
-
-function passwordConfirmErrorMessage () {
-  switch (validatePasswordConfirm()) {
-    case 'pwConfirmEmpty':
-      addInputMessage(signupPasswordConfirm, '비밀번호 확인을 입력해 주세요.');
-      break;
-    case 'pwConfirmLenError':
-      addInputMessage(signupPasswordConfirm, '비밀번호는 영어, 숫자 8자 이상 입력해 주세요.');
-      break;
-    case 'pwConfirmError':
-      addInputMessage(signupPasswordConfirm, '비밀번호가 다릅니다.');  
-      break;
-    default:
-      removeInputMessage(signupPasswordConfirm);
-      break;
-  }
-}
-
-function validateEmail () { // 이메일
-  const regex = new RegExp('^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$');
-  const user = users.find(data => data.email === signupEmail.value.trim()) ?? '';
-  if (signupEmail.value.trim() === '') {
-    validateObject.email = false;
-    return 'emailEmpty'
-  } else if (!regex.test(signupEmail.value.trim())) {
-    validateObject.email = false;
-    return 'emailError'
-  } else if (user.email === signupEmail.value.trim()) {
-    validateObject.email = false;
-    return 'emailSameName'
-  } else {
-    validateObject.email = true;
-    return ''
-  }
-}
-
-function validatePassword () { // 비밀번호
-  const regex = new RegExp('^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$');
-  if (signupPassword.value.trim() === '') {
-    validateObject.password = false;
-    return 'pwEmpty'
-  } else if (!regex.test(signupPassword.value.trim())) {
-    validateObject.password = false;
-    return 'pwLenError'
-  } else {
-    validateObject.password = true;
-    return ''
-  }
-}
-
-function validatePasswordConfirm () { // 비밀번호 확인
-  const regex = new RegExp('^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$');
-  if (signupPasswordConfirm.value.trim() === '') {
-    validateObject.passwordConfirm = false;
-    return 'pwConfirmEmpty'
-  } else if (signupPassword.value.trim() !== signupPasswordConfirm.value.trim()) {
-    validateObject.passwordConfirm = false;
-    return 'pwConfirmError'
-  } else if (!regex.test(signupPassword.value.trim())) {
-    validateObject.passwordConfirm = false;
-    return 'pwConfirmLenError'
-  } else {
-    validateObject.passwordConfirm = true;
-    return ''
-  }
-}
-
-function addInputMessage (target, massage) { // error massage add
-  const parent = target.closest('.form__box');
-  parent.classList.add('error');
-  parent.querySelector('.error__text').innerText = massage;
-}
-
-function removeInputMessage (target) { // error massage remove
-  const parent = target.closest('.form__box');
-  parent.classList.remove('error');
-  parent.querySelector('.error__text').innerText = ''
-}
-
 function focusOutInput (e) {
   const { target } = e;
+
   if(target.id === signupEmail.id) {
-    emailErrorMessage();
+    emailErrorMessage(signupEmail);
   };
 
   if(target.id === signupPassword.id) {
-    passwordErrorMessage ();
+    passwordErrorMessage (signupPassword);
   };
 
   if(target.id === signupPasswordConfirm.id) {
-    passwordConfirmErrorMessage ();
+    passwordConfirmErrorMessage (signupPassword, signupPasswordConfirm);
   };
   formActiveBtn();
 }
 
 function formActiveBtn () {
   const inputs = [validateObject.email,validateObject.password,validateObject.passwordConfirm].every(data => data === true);
+  
   if(inputs){
     submitButton.removeAttribute('disabled');
   } else {
@@ -151,9 +40,6 @@ function formActiveBtn () {
 
 function validateForm (e) { // form handler
   e.preventDefault();
-  validateEmail();
-  validatePassword();
-  validatePasswordConfirm();
   formActiveBtn();
   alert('회원가입을 하였습니다.');
   window.location.href='/signin.html';

--- a/js/utils.json
+++ b/js/utils.json
@@ -1,0 +1,3 @@
+[
+  { "email":"test@codeit.com", "pw":"codeit101" }
+]

--- a/signin.html
+++ b/signin.html
@@ -32,6 +32,10 @@
   <link rel="stylesheet" href="css/common/header.css">
   <link rel="stylesheet" href="css/common/footer.css">
   <link rel="stylesheet" href="css/page/join.css">
+  <script defer src="js/module/join/addErrorMessage.js"></script>
+  <script defer src="js/module/join/removeErrorMassage.js"></script>
+  <script defer src="js/module/join/validation.js"></script>
+  <script defer src="js/module/join/join.js"></script>
   <script defer src="js/signin.js"></script>
   <script defer src="js/password_toggle.js"></script>
 </head>
@@ -53,13 +57,13 @@
         <div class="form__wrap signin__form">
           <div class="form__box">
             <label for="email" class="text__size__s">이메일</label>
-            <input type="text" name="email" id="signin__email" autocomplete="off">
+            <input type="text" name="email" id="signin__email" autocomplete="on">
             <p class="error__text"></p>
           </div>
           <div class="form__box pw">
             <label for="signin__pw__input" class="text__size__s">비밀번호</label>
             <div class="form__relative">
-              <input type="password" name="pw" id="signin__pw__input" autocomplete="off">
+              <input type="password" name="pw" id="signin__pw__input" autocomplete="on">
               <button type="button" class="btn__pw signin__btn-pw">
                 <img src="img/icon/icon-eye-on.svg" alt="비밀번호 보기" class="icon__on">
                 <img src="img/icon/icon-eye-off.svg" alt="비밀번호 숨기기" class="icon__off">

--- a/signup.html
+++ b/signup.html
@@ -32,6 +32,10 @@
   <link rel="stylesheet" href="css/common/header.css">
   <link rel="stylesheet" href="css/common/footer.css">
   <link rel="stylesheet" href="css/page/join.css">
+  <script defer src="js/module/join/addErrorMessage.js"></script>
+  <script defer src="js/module/join/removeErrorMassage.js"></script>
+  <script defer src="js/module/join/validation.js"></script>
+  <script defer src="js/module/join/join.js"></script>
   <script defer src="js/signup.js"></script>
   <script defer src="js/password_toggle.js"></script>
 </head>


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] [기본]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- 회원가입시 아이디 중복여부 검사
- 비밀번호 숫자, 영어로 8글자 이상 작성하게 작업 및 검사
-  회원가입, 로그인 공통모듈작업

## 스크린샷

[피그마 보러가기](https://www.figma.com/file/dH3gN96jnAtMjxjhV80HM2/Weekly-Mission%5B5%EA%B8%B0%5D?type=design&node-id=439-2194&mode=design)

## 멘토에게

- 
