### PR TITLE
[오동혁] Week5

### DIFF
--- a/js/signin.js
+++ b/js/signin.js
@@ -1,28 +1,37 @@
-import { email_check, password_empty, type_change, toggle_input_error } from './signup.js';
+import { checkEmail, changeType, toggleInputBorder } from './signup.js';
 
-const email = document.querySelector('#email-input');
-const password = document.querySelector('#password-input');
-const emailMsg = document.querySelector('#email-msg');
-const passwordMsg = document.querySelector('#password-msg');
+const $email = document.querySelector('#email-input');
+const $password = document.querySelector('#password-input');
+const $emailMsg = document.querySelector('#email-msg');
+const $passwordMsg = document.querySelector('#password-msg');
 
 function login(e) {
   if (e.target.type == 'submit') e.preventDefault();
   if (e.type == 'keyup' && e.keyCode != '13') return; 
 
-  if (email.value == 'test@codeit.com' && password.value == 'codeit101') {
+  if ($email.value == 'test@codeit.com' && $password.value == 'codeit101') {
     location.href = 'folder';
   } else {
-    emailMsg.textContent = '이메일을 확인해주세요.';
-    passwordMsg.textContent = '비밀번호를 확인해 주세요.';
-    emailMsg.hidden = false;
-    passwordMsg.hidden = false;
-    toggle_input_error(emailMsg.hidden, email);
-    toggle_input_error(passwordMsg.hidden, password);
+    $emailMsg.textContent = '이메일을 확인해주세요.';
+    $passwordMsg.textContent = '비밀번호를 확인해 주세요.';
+    $emailMsg.hidden = false;
+    $passwordMsg.hidden = false;
+    toggleInputBorder($emailMsg.hidden, $email);
+    toggleInputBorder($passwordMsg.hidden, $password);
   }
 }
 
-email.addEventListener('focusout', email_check);
-password.addEventListener('focusout', password_empty);
-document.querySelector('#password-img').addEventListener('click', type_change);
+function checkPwdEmpty(e) {
+  const isEmpty = e.target.value.length === 0;
+  
+  $passwordMsg.textContent = isEmpty ? '비밀번호를 입력해 주세요.' : $passwordMsg.textContent;
+  $passwordMsg.hidden = isEmpty ? false : true;
+
+  toggleInputBorder($passwordMsg.hidden, e.target);
+}
+
+$email.addEventListener('focusout', checkEmail);
+$password.addEventListener('focusout', checkPwdEmpty);
+document.querySelector('#password-img').addEventListener('click', changeType);
 document.querySelector('#login').addEventListener('keyup', login);
 document.querySelector('#signin').addEventListener('click', login);

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,78 +1,104 @@
-const email = document.querySelector('#email-input');
-const password = document.querySelector('#password-input');
-const repeat = document.querySelector('#password-repeat-input');
-const emailMsg = document.querySelector('#email-msg');
-const passwordMsg = document.querySelector('#password-msg');
-const repeatMsg = document.querySelector('#password-repeat-msg');
+const $email = document.querySelector('#email-input');
+const $password = document.querySelector('#password-input');
+const $repeat = document.querySelector('#password-repeat-input');
+const $emailMsg = document.querySelector('#email-msg');
+const $passwordMsg = document.querySelector('#password-msg');
+const $repeatMsg = document.querySelector('#password-repeat-msg');
 
-function email_check(e) {
-  let regex = new RegExp('^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$');
-  let test = regex.test(e.target.value);
+function checkEmail(e) {
+  const isDuplicate = $email.value === 'test@codeit.com' ? true : false;
+  const isEmail = /^[a-zA-Z0-9+-\_.]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/.test(e.target.value);
+  const isEmpty = e.target.value.length === 0;
+  const isSignUp = location.pathname.includes('signup');
 
-  emailMsg.textContent = e.target.value.length == 0 ? '이메일을 입력해 주세요.' : '';
-  emailMsg.textContent = e.target.value.length != 0 && !test ? '올바른 이메일 주소가 아닙니다.' : emailMsg.textContent;
-  emailMsg.hidden = e.target.value.length == 0 ? false : true;
-  if (emailMsg.hidden) emailMsg.hidden = e.target.value.length != 0 && !test ? false : true;
+  if (isSignUp && isDuplicate) {
+    $emailMsg.textContent = '이미 사용중인 이메일입니다.';
+    $emailMsg.hidden = false;
+  } else {
+    $emailMsg.textContent = isEmpty ? '이메일을 입력해 주세요.' : (!isEmail ? '올바른 이메일 주소가 아닙니다.' : $emailMsg.textContent);
+    $emailMsg.hidden = isEmpty ? false : (!isEmail ? false : true);
+  }
 
-  toggle_input_error(emailMsg.hidden, email);
+  toggleInputBorder($emailMsg.hidden, $email);
+
+  return $emailMsg.hidden;
 }
 
-function type_change(e) {
-  let password_img = e.target;
-  let password_input = document.getElementById(e.target.id == 'password-img' ? 'password-input' : 'password-repeat-input');
+function changeType(e) {
+  const $passwordImg = e.target;
+  const $passwordInput = document.getElementById(e.target.id == 'password-img' ? 'password-input' : 'password-repeat-input');
 
-  let src = password_img.getAttribute('src');
-  if (src == 'img/eye-on.png') {
-    password_img.setAttribute('src', 'img/eye-off.png');
-    password_input.setAttribute('type', 'text');
+  let src = $passwordImg.getAttribute('src');
+  if (src === 'img/eye-on.png') {
+    $passwordImg.setAttribute('src', 'img/eye-off.png');
+    $passwordInput.setAttribute('type', 'text');
   } else {
-    password_img.setAttribute('src', 'img/eye-on.png');
-    password_input.setAttribute('type', 'password');
+    $passwordImg.setAttribute('src', 'img/eye-on.png');
+    $passwordInput.setAttribute('type', 'password');
   }
 }
 
-function diff_check() {
-  if (repeat.value == '') {
-    repeat.classList.remove('input-error');
-    repeatMsg.hidden = true;
-    repeatMsg.textContent = '';
+function checkPwdType(e) {
+  const errmsg = '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.';
+  
+  if (!/^(?=.*[a-zA-Z])(?=.*[0-9]).{8,25}$/.test(e.target.value)) {
+    $passwordMsg.textContent = errmsg;
+    $passwordMsg.hidden = false;
+  } else if ($passwordMsg.textContent === errmsg){
+    $passwordMsg.textContent = '';
+    $passwordMsg.hidden = true;
+  }
+
+  return $passwordMsg.hidden;
+}
+
+function checkPwdDiff() {
+  if ($repeat.value === '') {
+    $repeat.classList.remove('input-error');
+    $repeatMsg.hidden = true;
+    $repeatMsg.textContent = '';
   } else {
-    if (password.value == repeat.value) {
-      repeat.classList.remove('input-error');
-      repeatMsg.hidden = true;
-      repeatMsg.textContent = '';
+    if ($password.value === $repeat.value) {
+      $repeat.classList.remove('input-error');
+      $repeatMsg.hidden = true;
+      $repeatMsg.textContent = '';
     } else {
-      repeat.classList.add('input-error');
-      repeatMsg.textContent = '비밀번호가 다릅니다.';
-      repeatMsg.hidden = false;
+      $repeat.classList.add('input-error');
+      $repeatMsg.textContent = '비밀번호가 일치하지 않아요.';
+      $repeatMsg.hidden = false;
     }
   }
+
+  return $repeatMsg.hidden;
 }
 
-function password_empty(e) {
-  let msg = e.target.id.includes('repeat') ? repeatMsg || passwordMsg : passwordMsg;
-  
-  if (msg.textContent != '비밀번호가 다릅니다.') {
-    msg.textContent = '비밀번호를 입력해 주세요.';
-    msg.hidden = e.target.value.length == 0 ? false : true;
-
-    toggle_input_error(msg.hidden, e.target);
-  }
-}
-
-function toggle_input_error(hidden, input) {
+function toggleInputBorder(hidden, input) {
   if (!hidden) input.classList.add('input-error');
   else input.classList.remove('input-error');
 }
 
-if (location.pathname.includes('signup')) {
-  email.addEventListener('focusout', email_check);
-  password.addEventListener('focusout', password_empty);
-  password.addEventListener('input', diff_check);
-  document.querySelector('#password-img').addEventListener('click', type_change);
-  document.querySelector('#password-repeat-img').addEventListener('click', type_change);
-  repeat.addEventListener('focusout', password_empty);
-  repeat.addEventListener('input', diff_check);
+function register(e) {
+  if (e.target.type == 'submit') e.preventDefault();
+  if (e.type == 'keyup' && e.keyCode != '13') return; 
+  
+  const hasErrEmail = checkEmail({ target: $email });
+  const hasErrPwdType = checkPwdType({ target: $password });
+  const hasErrPwdDiff = checkPwdDiff();
+  
+  if (hasErrEmail && hasErrPwdType && hasErrPwdDiff) {
+    location.href = 'folder';
+  }
 }
 
-export { email_check, password_empty, type_change, toggle_input_error };
+if (location.pathname.includes('signup')) {
+  $email.addEventListener('focusout', checkEmail);
+  $password.addEventListener('input', checkPwdDiff);
+  $password.addEventListener('focusout', checkPwdType);
+  document.querySelector('#password-img').addEventListener('click', changeType);
+  document.querySelector('#password-repeat-img').addEventListener('click', changeType);
+  $repeat.addEventListener('input', checkPwdDiff);
+  document.querySelector('#register').addEventListener('keyup', register);
+  document.querySelector('#signup').addEventListener('click', register);
+}
+
+export { checkEmail, changeType, toggleInputBorder };


### PR DESCRIPTION
## 요구사항

### 기본

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 일 때, input 값이 [test@codeit.com](mailto:test@codeit.com) 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] 이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] 이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [x] 로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

-
-

## 스크린샷

## 멘토에게

- 이전 리뷰의 내용을 반영해보았습니다.
