### PR TITLE
[유호민] Week5

### DIFF
--- a/weeklyMission1/css/style.css
+++ b/weeklyMission1/css/style.css
@@ -323,6 +323,21 @@ a.navbar-login {
     line-height: normal;
     cursor: pointer;
 }
+.signup-btn {
+    width: 100%;
+    text-align: center;
+    margin-top: 30px;
+    padding: 16px 20px;
+    border-radius: 8px;
+    background: var(--gra-purpleblue-to-skyblue, linear-gradient(91deg, #6D6AFE 0.12%, #6AE3FE 101.84%));
+    color: var(--Grey-Light, #F5F5F5);
+    font-family: Pretendard;
+    font-size: 18px;
+    font-style: normal;
+    font-weight: 600;
+    line-height: normal;
+    cursor: pointer;
+}
 
 .signin-social-login {
     padding: 12px 24px;

--- a/weeklyMission1/css/style.css
+++ b/weeklyMission1/css/style.css
@@ -341,6 +341,18 @@ a.navbar-login {
     color: red;
 }
 
+.signup-email-error-msg {
+    margin-top: 10px;
+    font-size: 14px;
+    color: red;
+}
+
+.signup-password-error-msg {
+    margin-top: 10px;
+    font-size: 14px;
+    color: red;
+}
+
 .password-error-msg {
     margin-top: 10px;
     font-size: 14px;

--- a/weeklyMission1/css/style.css
+++ b/weeklyMission1/css/style.css
@@ -347,6 +347,12 @@ a.navbar-login {
     color: red;
 }
 
+.password-check-error-msg {
+    margin-top: 10px;
+    font-size: 14px;
+    color: red;
+}
+
 .signin-social-login p {
     color: var(--Linkbrary-gray100, #373740);
     font-family: Pretendard;

--- a/weeklyMission1/index.js
+++ b/weeklyMission1/index.js
@@ -1,10 +1,15 @@
 const signInEmailInput = document.querySelector('.signin-email-input');
-const signUpEmailInput = document.querySelector('.signup-email-input');
 const signInPasswordInput = document.querySelector('.signin-password-input');
+const signUpEmailInput = document.querySelector('.signup-email-input');
+const signUpPasswordInput = document.querySelector('.signup-password-input');
 const emailErrorMsg = document.querySelector('.email-error-msg');
+const signUpEmailErrorMsg = document.querySelector('.signup-email-error-msg');
+const signUpPasswordCheckInput = document.querySelector('.signup-password-check-input');
+const passwordCheckErrorMsg = document.querySelector('.password-check-error-msg');
 const passwordErrorMsg = document.querySelector('.password-error-msg');
 const signInLogin = document.querySelector('.signin-login');
 const passwordImg = document.querySelector('.password-img');
+const passwordImgCheck = document.querySelector('.password-img-check');
 const MEMBER_ID = "test@codeit.com";
 const MEMBER_PASSWORD = "codeit101";
 
@@ -26,28 +31,71 @@ function checkEmail(emailInput) {
     }
 }
 
+function checkEmailValid() {
+    const signInEmailInputValue = signInEmailInput.value;
+
+    if (!checkEmail(signInEmailInputValue)) {
+        emailErrorMsg.textContent = "올바른 이메일 주소가 아닙니다.";
+        signInEmailInput.style.border = "1px solid red";
+    } else {
+        emailErrorMsg.textContent = "";
+        signInEmailInput.style.border = "1px solid #9fa6b2";
+    }
+}
+
 function checkEmailDuplicate() {
     const signUpEmailInputValue = signUpEmailInput.value;
 
     if (signUpEmailInputValue === MEMBER_ID) {
-        emailErrorMsg.textContent = "이미 사용 중인 이메일입니다."
-        signInEmailInput.style.border = "1px solid red";
+        signUpEmailErrorMsg.textContent = "이미 사용 중인 이메일입니다.";
     }
-}
-
-function checkEmailValid() {
-    const signInEmailInputValue = signInEmailInput.value;
-    const isCheckEmail = checkEmail(signInEmailInputValue);
-
-    emailErrorMsg.textContent = isCheckEmail ? '' : "올바른 이메일 주소가 아닙니다.";
-    signInEmailInput.style.border = `1px solid ${isCheckEmail ? "#9fa6b2" : "red"}`;
 }
 
 function checkPasswordBlank() {
     const signInPasswordInputValue = signInPasswordInput.value;
 
-    passwordErrorMsg.textContent  = signInPasswordInputValue ? "" : "비밀번호를 입력해주세요.";
-    signInPasswordInput.style.border = `1px solid ${signInPasswordInputValue ? "#9fa6b2" : "red"}`;
+    if (!signInPasswordInputValue) {
+        passwordErrorMsg.textContent = "비밀번호를 입력해주세요.";
+        signInPasswordInput.style.border = "1px solid red";
+    } else {
+        passwordErrorMsg.textContent = "";
+        signInPasswordInput.style.border = "1px solid #9fa6b2";
+    }
+}
+
+function checkPassword(passwordInput) {
+    const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d]{8,20}$/;
+
+    if (!passwordRegex.test(passwordInput)) {
+        return false;
+    } else {
+        return true;
+    }
+}
+
+function checkPasswordValid() {
+    const signUpPasswordInputValue = signUpPasswordInput.value;
+
+    if (!checkPassword(signUpPasswordInputValue)) {
+        passwordErrorMsg.textContent = "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.";
+        signUpPasswordInput.style.border = "1px solid red";
+    } else {
+        passwordErrorMsg.textContent = "";
+        signUpPasswordInput.style.border = "1px solid #9fa6b2";
+    }
+}
+
+function checkPasswordDuplicate() {
+    const signInPasswordInputValue = signInPasswordInput.value;
+    const signUpPasswordCheckInputValue = signUpPasswordCheckInput.value;
+
+    if (signInPasswordInputValue !== signUpPasswordCheckInputValue) {
+        passwordCheckErrorMsg.textContent = "비밀번호가 일치하지 않아요.";
+        signUpPasswordCheckInput.style.border = "1px solid red";
+    } else {
+        passwordCheckErrorMsg.textContent = "";
+        signUpPasswordCheckInput.style.border = "1px solid #9fa6b2";
+    }
 }
 
 function checkMember() {
@@ -65,12 +113,26 @@ function checkMember() {
 }
 
 function passwordToggle() {
-    if (passwordImg.getAttribute('src') === "./img/hidden.svg") {
+    if (passwordImg.getAttribute('alt') === "closed-eye") {
+        passwordImg.setAttribute('alt', "opened-eye");
         passwordImg.setAttribute('src', "./img/unhidden.svg");
         signInPasswordInput.setAttribute('type', 'text');
-    } else {
+    } else if (passwordImg.getAttribute('alt') === "opened-eye") {
+        passwordImg.setAttribute('alt', "closed-eye");
         passwordImg.setAttribute('src', "./img/hidden.svg");
         signInPasswordInput.setAttribute('type', 'password');
+    }
+}
+
+function passwordToggleCheck() {
+    if (passwordImgCheck.getAttribute('alt') === "opened-eye-second") {
+        passwordImgCheck.setAttribute('alt', "closed-eye-second");
+        passwordImgCheck.setAttribute('src', "./img/hidden.svg");
+        signUpPasswordCheckInput.setAttribute('type', 'password');
+    } else if (passwordImgCheck.getAttribute('alt') === "closed-eye-second") {
+        passwordImgCheck.setAttribute('alt', "opened-eye-second");
+        passwordImgCheck.setAttribute('src', "./img/unhidden.svg");
+        signUpPasswordCheckInput.setAttribute('type', 'text');
     }
 }
 
@@ -86,12 +148,16 @@ signInEmailInput.addEventListener('blur', checkEmailBlank);
 signInEmailInput.addEventListener('input', checkEmailBlank);
 signInEmailInput.addEventListener('keydown', pressEnterToLogin);
 
-signUpEmailInput.addEventListener('blur', checkEmailDuplicate);
-signUpEmailInput.addEventListener('input', checkEmailDuplicate);
-
 signInPasswordInput.addEventListener('blur', checkPasswordBlank);
 signInPasswordInput.addEventListener('input', checkPasswordBlank);
 signInPasswordInput.addEventListener('keydown', pressEnterToLogin);
 
 signInLogin.addEventListener('click', checkMember);
 passwordImg.addEventListener('click', passwordToggle);
+passwordImgCheck.addEventListener('click', passwordToggleCheck);
+
+signUpEmailInput.addEventListener('blur', checkEmailDuplicate);
+signUpEmailInput.addEventListener('input', checkEmailDuplicate);
+
+signUpPasswordCheckInput.addEventListener('input', checkPasswordDuplicate);
+signUpPasswordInput.addEventListener('input', checkPasswordValid);

--- a/weeklyMission1/index.js
+++ b/weeklyMission1/index.js
@@ -4,6 +4,8 @@ const emailErrorMsg = document.querySelector('.email-error-msg');
 const passwordErrorMsg = document.querySelector('.password-error-msg');
 const signInLogin = document.querySelector('.signin-login');
 const passwordImg = document.querySelector('.password-img');
+const MEMBER_ID = "test@codeit.com";
+const MEMBER_PASSWORD = "codeit101";
 
 function checkEmailBlank() {
     const signInEmailInputValue = signInEmailInput.value;
@@ -50,10 +52,8 @@ function checkPasswordBlank() {
 function checkMember() {
     const signInEmailInputValue = signInEmailInput.value;
     const signInPasswordInputValue = signInPasswordInput.value;
-    const memberId = "test@codeit.com";
-    const memberPassword = "codeit101";
 
-    if (signInEmailInputValue === memberId && signInPasswordInputValue === memberPassword) {
+    if (signInEmailInputValue === MEMBER_ID && signInPasswordInputValue === MEMBER_PASSWORD) {
         window.location.href = '/folder';
     } else {
         emailErrorMsg.textContent = "이메일을 확인해주세요.";

--- a/weeklyMission1/index.js
+++ b/weeklyMission1/index.js
@@ -1,4 +1,5 @@
 const signInEmailInput = document.querySelector('.signin-email-input');
+const signUpEmailInput = document.querySelector('.signup-email-input');
 const signInPasswordInput = document.querySelector('.signin-password-input');
 const emailErrorMsg = document.querySelector('.email-error-msg');
 const passwordErrorMsg = document.querySelector('.password-error-msg');
@@ -25,17 +26,18 @@ function checkEmail(emailInput) {
     }
 }
 
+function checkEmailDuplicate() {
+    const signUpEmailInputValue = signUpEmailInput.value;
+
+    if (signUpEmailInputValue === MEMBER_ID) {
+        emailErrorMsg.textContent = "이미 사용 중인 이메일입니다."
+        signInEmailInput.style.border = "1px solid red";
+    }
+}
+
 function checkEmailValid() {
     const signInEmailInputValue = signInEmailInput.value;
     const isCheckEmail = checkEmail(signInEmailInputValue);
-
-    // if (!checkEmail(signInEmailInputValue)) {
-    //     emailErrorMsg.textContent = "올바른 이메일 주소가 아닙니다.";
-    //     signInEmailInput.style.border = "1px solid red";
-    // } else {
-    //     emailErrorMsg.textContent = "";
-    //     signInEmailInput.style.border = "1px solid #9fa6b2";
-    // }
 
     emailErrorMsg.textContent = isCheckEmail ? '' : "올바른 이메일 주소가 아닙니다.";
     signInEmailInput.style.border = `1px solid ${isCheckEmail ? "#9fa6b2" : "red"}`;
@@ -43,14 +45,6 @@ function checkEmailValid() {
 
 function checkPasswordBlank() {
     const signInPasswordInputValue = signInPasswordInput.value;
-
-    // if (!signInPasswordInputValue) {
-    //     passwordErrorMsg.textContent = "비밀번호를 입력해주세요.";
-    //     signInPasswordInput.style.border = "1px solid red";
-    // } else {
-    //     passwordErrorMsg.textContent = "";
-    //     signInPasswordInput.style.border = "1px solid #9fa6b2";
-    // }
 
     passwordErrorMsg.textContent  = signInPasswordInputValue ? "" : "비밀번호를 입력해주세요.";
     signInPasswordInput.style.border = `1px solid ${signInPasswordInputValue ? "#9fa6b2" : "red"}`;
@@ -91,6 +85,9 @@ signInEmailInput.addEventListener('input', checkEmailValid);
 signInEmailInput.addEventListener('blur', checkEmailBlank);
 signInEmailInput.addEventListener('input', checkEmailBlank);
 signInEmailInput.addEventListener('keydown', pressEnterToLogin);
+
+signUpEmailInput.addEventListener('blur', checkEmailDuplicate);
+signUpEmailInput.addEventListener('input', checkEmailDuplicate);
 
 signInPasswordInput.addEventListener('blur', checkPasswordBlank);
 signInPasswordInput.addEventListener('input', checkPasswordBlank);

--- a/weeklyMission1/index.js
+++ b/weeklyMission1/index.js
@@ -27,14 +27,18 @@ function checkEmail(emailInput) {
 
 function checkEmailValid() {
     const signInEmailInputValue = signInEmailInput.value;
+    const isCheckEmail = checkEmail(signInEmailInputValue);
 
-    if (!checkEmail(signInEmailInputValue)) {
-        emailErrorMsg.textContent = "올바른 이메일 주소가 아닙니다.";
-        signInEmailInput.style.border = "1px solid red";
-    } else {
-        emailErrorMsg.textContent = "";
-        signInEmailInput.style.border = "1px solid #9fa6b2";
-    }
+    // if (!checkEmail(signInEmailInputValue)) {
+    //     emailErrorMsg.textContent = "올바른 이메일 주소가 아닙니다.";
+    //     signInEmailInput.style.border = "1px solid red";
+    // } else {
+    //     emailErrorMsg.textContent = "";
+    //     signInEmailInput.style.border = "1px solid #9fa6b2";
+    // }
+
+    emailErrorMsg.textContent = isCheckEmail ? '' : "올바른 이메일 주소가 아닙니다.";
+    signInEmailInput.style.border = `1px solid ${isCheckEmail ? "#9fa6b2" : "red"}`;
 }
 
 function checkPasswordBlank() {

--- a/weeklyMission1/index.js
+++ b/weeklyMission1/index.js
@@ -44,13 +44,16 @@ function checkEmailValid() {
 function checkPasswordBlank() {
     const signInPasswordInputValue = signInPasswordInput.value;
 
-    if (!signInPasswordInputValue) {
-        passwordErrorMsg.textContent = "비밀번호를 입력해주세요.";
-        signInPasswordInput.style.border = "1px solid red";
-    } else {
-        passwordErrorMsg.textContent = "";
-        signInPasswordInput.style.border = "1px solid #9fa6b2";
-    }
+    // if (!signInPasswordInputValue) {
+    //     passwordErrorMsg.textContent = "비밀번호를 입력해주세요.";
+    //     signInPasswordInput.style.border = "1px solid red";
+    // } else {
+    //     passwordErrorMsg.textContent = "";
+    //     signInPasswordInput.style.border = "1px solid #9fa6b2";
+    // }
+
+    passwordErrorMsg.textContent  = signInPasswordInputValue ? "" : "비밀번호를 입력해주세요.";
+    signInPasswordInput.style.border = `1px solid ${signInPasswordInputValue ? "#9fa6b2" : "red"}`;
 }
 
 function checkMember() {

--- a/weeklyMission1/member.js
+++ b/weeklyMission1/member.js
@@ -1,0 +1,2 @@
+export const MEMBER_ID = "test@codeit.com";
+export const MEMBER_PASSWORD = "codeit101";

--- a/weeklyMission1/signin.html
+++ b/weeklyMission1/signin.html
@@ -27,7 +27,7 @@
         <div class="signin-password">
             <p>비밀번호</p>
             <input class="signin-password-input" id="signInPw" type="password" placeholder="password">
-            <img src="./img/hidden.svg" class="password-img" alt="closed eye">
+            <img src="./img/hidden.svg" class="password-img" alt="closed-eye">
             <div class="password-error-msg"></div>
         </div>
         <!-- <a href="/"> -->

--- a/weeklyMission1/signin.html
+++ b/weeklyMission1/signin.html
@@ -54,6 +54,6 @@
         </div>
     </div>
 
-    <script src="index.js"></script>
+    <script type="module" src="signin.js"></script>
 </body>
 </html>

--- a/weeklyMission1/signin.js
+++ b/weeklyMission1/signin.js
@@ -1,15 +1,11 @@
 const signInEmailInput = document.querySelector('.signin-email-input');
 const signInPasswordInput = document.querySelector('.signin-password-input');
-const signUpEmailInput = document.querySelector('.signup-email-input');
-const signUpPasswordInput = document.querySelector('.signup-password-input');
 const emailErrorMsg = document.querySelector('.email-error-msg');
-const signUpEmailErrorMsg = document.querySelector('.signup-email-error-msg');
 const signUpPasswordCheckInput = document.querySelector('.signup-password-check-input');
 const passwordCheckErrorMsg = document.querySelector('.password-check-error-msg');
 const passwordErrorMsg = document.querySelector('.password-error-msg');
 const signInLogin = document.querySelector('.signin-login');
 const passwordImg = document.querySelector('.password-img');
-const passwordImgCheck = document.querySelector('.password-img-check');
 const MEMBER_ID = "test@codeit.com";
 const MEMBER_PASSWORD = "codeit101";
 
@@ -19,11 +15,12 @@ function checkEmailBlank() {
     if (!signInEmailInputValue) {
         emailErrorMsg.textContent = "이메일을 입력해주세요.";
         signInEmailInput.style.border = "1px solid red";
-    }
+    } 
 }
 
 function checkEmail(emailInput) {
     const emailRegex = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-Za-z0-9\-]+/;
+    
     if (!emailRegex.test(emailInput)) {
         return false;
     } else {
@@ -43,14 +40,6 @@ function checkEmailValid() {
     }
 }
 
-function checkEmailDuplicate() {
-    const signUpEmailInputValue = signUpEmailInput.value;
-
-    if (signUpEmailInputValue === MEMBER_ID) {
-        signUpEmailErrorMsg.textContent = "이미 사용 중인 이메일입니다.";
-    }
-}
-
 function checkPasswordBlank() {
     const signInPasswordInputValue = signInPasswordInput.value;
 
@@ -60,41 +49,6 @@ function checkPasswordBlank() {
     } else {
         passwordErrorMsg.textContent = "";
         signInPasswordInput.style.border = "1px solid #9fa6b2";
-    }
-}
-
-function checkPassword(passwordInput) {
-    const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d]{8,20}$/;
-
-    if (!passwordRegex.test(passwordInput)) {
-        return false;
-    } else {
-        return true;
-    }
-}
-
-function checkPasswordValid() {
-    const signUpPasswordInputValue = signUpPasswordInput.value;
-
-    if (!checkPassword(signUpPasswordInputValue)) {
-        passwordErrorMsg.textContent = "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.";
-        signUpPasswordInput.style.border = "1px solid red";
-    } else {
-        passwordErrorMsg.textContent = "";
-        signUpPasswordInput.style.border = "1px solid #9fa6b2";
-    }
-}
-
-function checkPasswordDuplicate() {
-    const signInPasswordInputValue = signInPasswordInput.value;
-    const signUpPasswordCheckInputValue = signUpPasswordCheckInput.value;
-
-    if (signInPasswordInputValue !== signUpPasswordCheckInputValue) {
-        passwordCheckErrorMsg.textContent = "비밀번호가 일치하지 않아요.";
-        signUpPasswordCheckInput.style.border = "1px solid red";
-    } else {
-        passwordCheckErrorMsg.textContent = "";
-        signUpPasswordCheckInput.style.border = "1px solid #9fa6b2";
     }
 }
 
@@ -124,18 +78,6 @@ function passwordToggle() {
     }
 }
 
-function passwordToggleCheck() {
-    if (passwordImgCheck.getAttribute('alt') === "opened-eye-second") {
-        passwordImgCheck.setAttribute('alt', "closed-eye-second");
-        passwordImgCheck.setAttribute('src', "./img/hidden.svg");
-        signUpPasswordCheckInput.setAttribute('type', 'password');
-    } else if (passwordImgCheck.getAttribute('alt') === "closed-eye-second") {
-        passwordImgCheck.setAttribute('alt', "opened-eye-second");
-        passwordImgCheck.setAttribute('src', "./img/unhidden.svg");
-        signUpPasswordCheckInput.setAttribute('type', 'text');
-    }
-}
-
 function pressEnterToLogin(e) {
     if (e.key === 'Enter') {
         checkMember();
@@ -154,10 +96,3 @@ signInPasswordInput.addEventListener('keydown', pressEnterToLogin);
 
 signInLogin.addEventListener('click', checkMember);
 passwordImg.addEventListener('click', passwordToggle);
-passwordImgCheck.addEventListener('click', passwordToggleCheck);
-
-signUpEmailInput.addEventListener('blur', checkEmailDuplicate);
-signUpEmailInput.addEventListener('input', checkEmailDuplicate);
-
-signUpPasswordCheckInput.addEventListener('input', checkPasswordDuplicate);
-signUpPasswordInput.addEventListener('input', checkPasswordValid);

--- a/weeklyMission1/signin.js
+++ b/weeklyMission1/signin.js
@@ -1,13 +1,5 @@
-const signInEmailInput = document.querySelector('.signin-email-input');
-const signInPasswordInput = document.querySelector('.signin-password-input');
-const emailErrorMsg = document.querySelector('.email-error-msg');
-const signUpPasswordCheckInput = document.querySelector('.signup-password-check-input');
-const passwordCheckErrorMsg = document.querySelector('.password-check-error-msg');
-const passwordErrorMsg = document.querySelector('.password-error-msg');
-const signInLogin = document.querySelector('.signin-login');
-const passwordImg = document.querySelector('.password-img');
-const MEMBER_ID = "test@codeit.com";
-const MEMBER_PASSWORD = "codeit101";
+import { MEMBER_ID, MEMBER_PASSWORD } from "./member.js";
+import { signInEmailInput, signInPasswordInput, emailErrorMsg, passwordErrorMsg, signInLogin, passwordImg } from "./tags.js";
 
 function checkEmailBlank() {
     const signInEmailInputValue = signInEmailInput.value;
@@ -52,7 +44,7 @@ function checkPasswordBlank() {
     }
 }
 
-function checkMember() {
+function checkMember(e) {
     const signInEmailInputValue = signInEmailInput.value;
     const signInPasswordInputValue = signInPasswordInput.value;
 

--- a/weeklyMission1/signup.html
+++ b/weeklyMission1/signup.html
@@ -27,20 +27,20 @@
         <div class="signin-password">
             <p>비밀번호</p>
             <input class="signup-password-input" id="signInPw" type="password" placeholder="password">
-            <img src="./img/unhidden.svg" class="password-img" alt="opened-eye">
+            <img src="./img/hidden.svg" class="password-img" alt="closed-eye">
             <div class="signup-password-error-msg"></div>
         </div>
         <div class="signin-password">
             <p>비밀번호확인</p>
             <input class="signup-password-check-input" id="signInPw" type="password" placeholder="password">
-            <img src="./img/unhidden.svg" class="password-img-check" alt="opened-eye-second">
+            <img src="./img/hidden.svg" class="password-img-check" alt="closed-eye-second">
             <div class="password-check-error-msg"></div>
         </div>
-        <a href="/">
-            <div class="signin-login">
+        <!-- <a href="/"> -->
+            <div class="signup-btn">
                 회원가입
             </div>
-        </a>
+        <!-- </a> -->
         <div class="signin-social-login">
             <p>다른 방식으로 가입하기</p>
             <div class="signin-social-login-icons">

--- a/weeklyMission1/signup.html
+++ b/weeklyMission1/signup.html
@@ -21,8 +21,8 @@
         </div>
         <div class="signin-email">
             <p>이메일</p>
-            <input type="email" placeholder="codeit@codeit.com">
-            <div class="error-msg"></div>
+            <input class="signin-email-input signup-email-input" type="email" placeholder="codeit@codeit.com">
+            <div class="email-error-msg"></div>
         </div>
         <div class="signin-password">
             <p>비밀번호</p>

--- a/weeklyMission1/signup.html
+++ b/weeklyMission1/signup.html
@@ -22,18 +22,19 @@
         <div class="signin-email">
             <p>이메일</p>
             <input class="signin-email-input signup-email-input" type="email" placeholder="codeit@codeit.com">
-            <div class="email-error-msg"></div>
+            <div class="email-error-msg signup-email-error-msg"></div>
         </div>
         <div class="signin-password">
             <p>비밀번호</p>
-            <input id="signInPw" type="password" placeholder="password">
-            <img src="./img/unhidden.svg" alt="opened eye">
-            <div class="error-msg"></div>
+            <input class="signin-password-input signup-password-input" id="signInPw" type="password" placeholder="password">
+            <img src="./img/unhidden.svg" class="password-img" alt="opened-eye">
+            <div class="password-error-msg"></div>
         </div>
         <div class="signin-password">
             <p>비밀번호확인</p>
-            <input id="signInPw" type="password" placeholder="password">
-            <img src="./img/unhidden.svg" alt="opened eye">
+            <input class="signup-password-check-input" id="signInPw" type="password" placeholder="password">
+            <img src="./img/unhidden.svg" class="password-img-check" alt="opened-eye-second">
+            <div class="password-check-error-msg"></div>
         </div>
         <a href="/">
             <div class="signin-login">

--- a/weeklyMission1/signup.html
+++ b/weeklyMission1/signup.html
@@ -21,14 +21,14 @@
         </div>
         <div class="signin-email">
             <p>이메일</p>
-            <input class="signin-email-input signup-email-input" type="email" placeholder="codeit@codeit.com">
-            <div class="email-error-msg signup-email-error-msg"></div>
+            <input class="signup-email-input" type="email" placeholder="codeit@codeit.com">
+            <div class="signup-email-error-msg"></div>
         </div>
         <div class="signin-password">
             <p>비밀번호</p>
-            <input class="signin-password-input signup-password-input" id="signInPw" type="password" placeholder="password">
+            <input class="signup-password-input" id="signInPw" type="password" placeholder="password">
             <img src="./img/unhidden.svg" class="password-img" alt="opened-eye">
-            <div class="password-error-msg"></div>
+            <div class="signup-password-error-msg"></div>
         </div>
         <div class="signin-password">
             <p>비밀번호확인</p>
@@ -60,6 +60,6 @@
         </div>
     </div>
 
-    <script src="index.js"></script>
+    <script type="module" src="signup.js"></script>
 </body>
 </html>

--- a/weeklyMission1/signup.html
+++ b/weeklyMission1/signup.html
@@ -58,5 +58,7 @@
             </div>
         </div>
     </div>
+
+    <script src="index.js"></script>
 </body>
 </html>

--- a/weeklyMission1/signup.js
+++ b/weeklyMission1/signup.js
@@ -1,14 +1,6 @@
-const signUpEmailInput = document.querySelector('.signup-email-input');
-const signUpEmailErrorMsg = document.querySelector('.signup-email-error-msg');
-const signUpPasswordInput = document.querySelector('.signup-password-input');
-const signUpPasswordCheckInput = document.querySelector('.signup-password-check-input');
-const signUpPasswordErrorMsg = document.querySelector('.signup-password-error-msg');
-const passwordCheckErrorMsg = document.querySelector('.password-check-error-msg');
-const passwordImg = document.querySelector('.password-img');
-const passwordImgCheck = document.querySelector('.password-img-check');
-
-const MEMBER_ID = "test@codeit.com";
-const MEMBER_PASSWORD = "codeit101";
+import { MEMBER_ID } from "./member.js";
+import { signUpEmailInput, signUpEmailErrorMsg, signUpPasswordInput, signUpPasswordCheckInput, signUpPasswordErrorMsg, 
+    passwordCheckErrorMsg, passwordImg, passwordImgCheck, signUpBtn } from "./tags.js";
 
 function signUpCheckEmailBlank() {
     const signUpEmailInputValue = signUpEmailInput.value;
@@ -152,20 +144,11 @@ function passwordToggleCheck() {
     }
 }
 
-// 유효한 비밀번호인지 확인하는 조건들
-// 이메일이 빈칸인 경우 => O
-// 이메일이 중복인 경우 => O
-// 이메일이 유효하지 않은 경우 => O
-// 비밀번호가 빈칸인 경우 => O
-// 비밀번호가 유효하지 않은 경우 => O
-// 비밀번호 확인이 빈칸인 경우 => O
-// 비밀번호 확인이 일치하지 않은 경우 => O
-
 function checkMemberValid() {
     if (signUpCheckEmailBlank() === true) {
         signUpEmailErrorMsg.textContent = "이메일을 입력해주세요.";
         signUpEmailInput.style.border = "1px solid red";
-        
+
         return
     }
 
@@ -193,7 +176,7 @@ function checkMemberValid() {
     if (checkPasswordValid() === false) {
         signUpPasswordErrorMsg.textContent = "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.";
         signUpPasswordInput.style.border = "1px solid red";
-        console.log('checkpasswordvalid');
+        
         return
     }
 
@@ -211,7 +194,7 @@ function pressEnterToSignUp(e) {
     if (e.key === 'Enter') {
         checkMemberValid();
     }
-}
+} 
 
 signUpEmailInput.addEventListener('blur', signUpCheckEmailValid);
 signUpEmailInput.addEventListener('input', signUpCheckEmailValid);
@@ -232,3 +215,5 @@ signUpPasswordCheckInput.addEventListener('keydown', pressEnterToSignUp);
 
 passwordImg.addEventListener('click', passwordToggle);
 passwordImgCheck.addEventListener('click', passwordToggleCheck);
+
+signUpBtn.addEventListener('click', checkMemberValid);

--- a/weeklyMission1/signup.js
+++ b/weeklyMission1/signup.js
@@ -1,0 +1,234 @@
+const signUpEmailInput = document.querySelector('.signup-email-input');
+const signUpEmailErrorMsg = document.querySelector('.signup-email-error-msg');
+const signUpPasswordInput = document.querySelector('.signup-password-input');
+const signUpPasswordCheckInput = document.querySelector('.signup-password-check-input');
+const signUpPasswordErrorMsg = document.querySelector('.signup-password-error-msg');
+const passwordCheckErrorMsg = document.querySelector('.password-check-error-msg');
+const passwordImg = document.querySelector('.password-img');
+const passwordImgCheck = document.querySelector('.password-img-check');
+
+const MEMBER_ID = "test@codeit.com";
+const MEMBER_PASSWORD = "codeit101";
+
+function signUpCheckEmailBlank() {
+    const signUpEmailInputValue = signUpEmailInput.value;
+    let isSignUpCheckEmailBlank = false;
+
+    if (!signUpEmailInputValue) {
+        signUpEmailErrorMsg.textContent = "이메일을 입력해주세요.";
+        signUpEmailInput.style.border = "1px solid red";
+        isSignUpCheckEmailBlank = true;
+    }
+
+    return isSignUpCheckEmailBlank;
+}
+
+function signUpCheckEmail(emailInput) {
+    const emailRegex = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-Za-z0-9\-]+/;
+    
+    if (!emailRegex.test(emailInput)) {
+        return false;
+    } else {
+        return true;
+    }
+}
+
+function signUpCheckEmailValid() {
+    const signUpEmailInputValue = signUpEmailInput.value;
+    let isSignUpEmailValid = false;
+
+    if (!signUpCheckEmail(signUpEmailInputValue)) {
+        signUpEmailErrorMsg.textContent = "올바른 이메일 주소가 아닙니다.";
+        signUpEmailInput.style.border = "1px solid red";
+        isSignUpEmailValid = false;
+    } else {
+        signUpEmailErrorMsg.textContent = "";
+        signUpEmailInput.style.border = "1px solid #9fa6b2";
+        isSignUpEmailValid = true;
+    }
+
+    return isSignUpEmailValid;
+}
+
+function signUpcheckEmailDuplicate() {
+    const signUpEmailInputValue = signUpEmailInput.value;
+    let isEmailDuplicate = true;
+
+    if (signUpEmailInputValue === MEMBER_ID) {
+        signUpEmailErrorMsg.textContent = "이미 사용 중인 이메일입니다.";
+        signUpEmailInput.style.border = "1px solid red";
+        isEmailDuplicate = true;
+    } else {
+        isEmailDuplicate = false;
+    }
+
+    return isEmailDuplicate;
+}
+
+function signUpCheckPasswordBlank() {
+    const signUpPasswordInputValue = signUpPasswordInput.value;
+    let isSignUpCheckPasswordBlank = false;
+
+    if (!signUpPasswordInputValue) {
+        signUpPasswordErrorMsg.textContent = "비밀번호를 입력해주세요.";
+        signUpPasswordInput.style.border = "1px solid red";
+        isSignUpCheckPasswordBlank = true;
+    } else {
+        signUpPasswordErrorMsg.textContent = "";
+        signUpPasswordInput.style.border = "1px solid #9fa6b2";
+        isSignUpCheckPasswordBlank = false;
+    }
+
+    return isSignUpCheckPasswordBlank;
+}
+
+function checkPassword(passwordInput) {
+    const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d)[a-zA-Z\d]{8,20}$/;
+
+    if (!passwordRegex.test(passwordInput)) {
+        return false;
+    } else {
+        return true;
+    }
+}
+
+function checkPasswordValid() {
+    const signUpPasswordInputValue = signUpPasswordInput.value;
+    let isCheckPasswordValid = false;
+
+    if (!checkPassword(signUpPasswordInputValue)) {
+        signUpPasswordErrorMsg.textContent = "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.";
+        signUpPasswordInput.style.border = "1px solid red";
+        isCheckPasswordValid = false;
+    } else {
+        signUpPasswordErrorMsg.textContent = "";
+        signUpPasswordInput.style.border = "1px solid #9fa6b2";
+        isCheckPasswordValid = true;
+    }
+
+    return isCheckPasswordValid;
+
+}
+
+function checkPasswordDuplicate() {
+    const signUpPasswordInputValue = signUpPasswordInput.value;
+    const signUpPasswordCheckInputValue = signUpPasswordCheckInput.value;
+    let isCheckPasswordDuplicate = false;
+
+    if (signUpPasswordInputValue !== signUpPasswordCheckInputValue) {
+        passwordCheckErrorMsg.textContent = "비밀번호가 일치하지 않아요.";
+        signUpPasswordCheckInput.style.border = "1px solid red";
+        isCheckPasswordDuplicate = false;
+    } else {
+        passwordCheckErrorMsg.textContent = "";
+        signUpPasswordCheckInput.style.border = "1px solid #9fa6b2";
+        isCheckPasswordDuplicate = true;
+    }
+
+    return isCheckPasswordDuplicate;
+}
+
+function passwordToggle() {
+    if (passwordImg.getAttribute('alt') === "closed-eye") {
+        passwordImg.setAttribute('alt', "opened-eye");
+        passwordImg.setAttribute('src', "./img/unhidden.svg");
+        signUpPasswordInput.setAttribute('type', 'text');
+    } else if (passwordImg.getAttribute('alt') === "opened-eye") {
+        passwordImg.setAttribute('alt', "closed-eye");
+        passwordImg.setAttribute('src', "./img/hidden.svg");
+        signUpPasswordInput.setAttribute('type', 'password');
+    }
+}
+
+function passwordToggleCheck() {
+    if (passwordImgCheck.getAttribute('alt') === "opened-eye-second") {
+        passwordImgCheck.setAttribute('alt', "closed-eye-second");
+        passwordImgCheck.setAttribute('src', "./img/hidden.svg");
+        signUpPasswordCheckInput.setAttribute('type', 'password');
+    } else if (passwordImgCheck.getAttribute('alt') === "closed-eye-second") {
+        passwordImgCheck.setAttribute('alt', "opened-eye-second");
+        passwordImgCheck.setAttribute('src', "./img/unhidden.svg");
+        signUpPasswordCheckInput.setAttribute('type', 'text');
+    }
+}
+
+// 유효한 비밀번호인지 확인하는 조건들
+// 이메일이 빈칸인 경우 => O
+// 이메일이 중복인 경우 => O
+// 이메일이 유효하지 않은 경우 => O
+// 비밀번호가 빈칸인 경우 => O
+// 비밀번호가 유효하지 않은 경우 => O
+// 비밀번호 확인이 빈칸인 경우 => O
+// 비밀번호 확인이 일치하지 않은 경우 => O
+
+function checkMemberValid() {
+    if (signUpCheckEmailBlank() === true) {
+        signUpEmailErrorMsg.textContent = "이메일을 입력해주세요.";
+        signUpEmailInput.style.border = "1px solid red";
+        
+        return
+    }
+
+    if (signUpcheckEmailDuplicate() === true) {
+        signUpEmailErrorMsg.textContent = "이미 사용 중인 이메일입니다.";
+        signUpEmailInput.style.border = "1px solid red";
+
+        return
+    }
+
+    if (signUpCheckEmailValid() === false) {
+        signUpEmailErrorMsg.textContent = "올바른 이메일 주소가 아닙니다.";
+        signUpEmailInput.style.border = "1px solid red";
+
+        return
+    }
+
+    if (signUpCheckPasswordBlank() === true) {
+        signUpPasswordErrorMsg.textContent = "비밀번호를 입력해주세요.";
+        signUpPasswordInput.style.border = "1px solid red";
+        
+        return
+    }
+
+    if (checkPasswordValid() === false) {
+        signUpPasswordErrorMsg.textContent = "비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.";
+        signUpPasswordInput.style.border = "1px solid red";
+        console.log('checkpasswordvalid');
+        return
+    }
+
+    if (checkPasswordDuplicate() === false) {
+        passwordCheckErrorMsg.textContent = "비밀번호가 일치하지 않아요.";
+        signUpPasswordCheckInput.style.border = "1px solid red";
+        
+        return
+    } 
+
+    window.location.href = '/folder';
+}
+
+function pressEnterToSignUp(e) {
+    if (e.key === 'Enter') {
+        checkMemberValid();
+    }
+}
+
+signUpEmailInput.addEventListener('blur', signUpCheckEmailValid);
+signUpEmailInput.addEventListener('input', signUpCheckEmailValid);
+signUpEmailInput.addEventListener('blur', signUpCheckEmailBlank);
+signUpEmailInput.addEventListener('input', signUpCheckEmailBlank);
+signUpEmailInput.addEventListener('keydown', pressEnterToSignUp);
+
+signUpPasswordInput.addEventListener('blur', signUpCheckPasswordBlank);
+signUpPasswordInput.addEventListener('input', signUpCheckPasswordBlank);
+signUpPasswordInput.addEventListener('keydown', pressEnterToSignUp);
+
+signUpEmailInput.addEventListener('blur', signUpcheckEmailDuplicate);
+signUpEmailInput.addEventListener('input', signUpcheckEmailDuplicate);
+
+signUpPasswordInput.addEventListener('input', checkPasswordValid);
+signUpPasswordCheckInput.addEventListener('input', checkPasswordDuplicate);
+signUpPasswordCheckInput.addEventListener('keydown', pressEnterToSignUp);
+
+passwordImg.addEventListener('click', passwordToggle);
+passwordImgCheck.addEventListener('click', passwordToggleCheck);

--- a/weeklyMission1/tags.js
+++ b/weeklyMission1/tags.js
@@ -1,0 +1,20 @@
+const signUpEmailInput = document.querySelector('.signup-email-input');
+const signUpEmailErrorMsg = document.querySelector('.signup-email-error-msg');
+const signUpPasswordInput = document.querySelector('.signup-password-input');
+const signUpPasswordCheckInput = document.querySelector('.signup-password-check-input');
+const signUpPasswordErrorMsg = document.querySelector('.signup-password-error-msg');
+const passwordCheckErrorMsg = document.querySelector('.password-check-error-msg');
+const passwordImg = document.querySelector('.password-img');
+const passwordImgCheck = document.querySelector('.password-img-check');
+const signUpBtn = document.querySelector('.signup-btn');
+
+const signInEmailInput = document.querySelector('.signin-email-input');
+const signInPasswordInput = document.querySelector('.signin-password-input');
+const emailErrorMsg = document.querySelector('.email-error-msg');
+const passwordErrorMsg = document.querySelector('.password-error-msg');
+const signInLogin = document.querySelector('.signin-login');
+
+export { signUpEmailInput, signUpEmailErrorMsg, signUpPasswordInput, signUpPasswordCheckInput, signUpPasswordErrorMsg, 
+        passwordCheckErrorMsg, passwordImg, passwordImgCheck, signUpBtn };
+
+export { signInEmailInput, signInPasswordInput, emailErrorMsg, passwordErrorMsg, signInLogin };


### PR DESCRIPTION
## 요구사항

### 기본

- [x] 이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] 이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] 비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] 회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] 이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] 회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [] 이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?


### 심화

- [x] 눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] 비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [] 로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

- getAttribute 시 src 가 아닌 alt로 구분했습니다.

## 스크린샷

![image](이
![Week5 signup](https://github.com/codeit-bootcamp-frontend/5-Weekly-Mission/assets/67790990/f628e7fd-d564-4ca7-a1ea-6f6ab591540e)
미지url)
<img width="1438" alt="Week5 signup1" src="https://github.com/codeit-bootcamp-frontend/5-Weekly-Mission/assets/67790990/7e6a96a4-8de5-47e1-8d80-023b3fdf0c54">


## 멘토에게

- 공통으로 사용되는 태그 부분은 한 곳에 모아서 작성했지만 비슷한 기능을 하는 함수 부분은 모듈화하지 못했습니다. 더 공부해서 높은 퀄리티의 코드를 작성할 수 있도록 하겠습니다.
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
