### PR TITLE
[김지민] Week5

### DIFF
--- a/js/signin.js
+++ b/js/signin.js
@@ -3,58 +3,83 @@ const $password = document.querySelector('.password-input');
 const $eyeBtn = document.querySelector('.eye-button');
 const $loginBtn = document.querySelector('.buttton-login');
 
-function emailValid(email){
-  const valid = /^[A-Za-z0-9_\.\-]+@[A-Za-z0-9\-]+\.[A-za-z0-9\-]+/;
+function isEmailValid(email){
+  const valid = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g;
   return valid.test(email);
 }
 
-function checkEmail(event) {
+function handleCheckEmail(event) {
   const email = this.value.trim();
   const errorEmail = document.querySelector('.error-email');
   if (email === '') {
     event.target.classList.add('hidden');
     errorEmail.textContent = '이메일을 입력해 주세요.';
-  } else if (!emailValid(email)) {
+    return;
+  } else if (!isEmailValid(email)) {
     event.target.classList.add('hidden');
     errorEmail.textContent = '올바른 이메일 주소가 아닙니다.';
+    return;
   } else {
     errorEmail.textContent = ' ';
     event.target.classList.remove('hidden');
+    return;
   }
 }
 
-$email.addEventListener('focusout', checkEmail);
+$email.addEventListener('focusout', handleCheckEmail);
 
-function checkPwd(event) {
+function handleCheckPwd(event) {
   const password = this.value.trim();
   const errorPwd = document.querySelector('.error-password');
   if (password === '') {
     event.target.classList.add('hidden');
     errorPwd.textContent = '비밀번호를 입력해 주세요.';
+    return;
   } else {
     errorPwd.textContent = ' ';
     event.target.classList.remove('hidden');
+    return;
   }
 }
 
-$password.addEventListener('focusout', checkPwd);
+$password.addEventListener('focusout', handleCheckPwd);
+
+const isTest = {
+  email: "test@codeit.com",
+  password: "codeit101",
+};
 
 function sendMyData() {
-  if($email.classList.contains('hidden') || $email.value !== 'test@codeit.com') {
+  if($email.value === isTest.email && $password.value === isTest.password) {
+    location.href = '../folder.html';
+  } else {
     document.querySelector('.error-email').textContent = '이메일을 확인해 주세요.';
     document.querySelector('.error-password').textContent = '비밀번호를 확인해 주세요.';
-  } else if($email.value === 'test@codeit.com' && $password.value === 'codeit101') {
-      location.href = '../folder.html';
-    }
+  }
   $email.value = '';
   $password.value = '';
 }
-$loginBtn.addEventListener('click', sendMyData);
+
+$loginBtn.addEventListener('submit', sendMyData);
+$loginBtn.addEventListener('click', function() {
+  if($loginBtn.type === 'submit') {
+    $loginBtn.type = 'button';
+  }
+  if($email.value === isTest.email && $password.value === isTest.password) {
+    location.href = '../folder.html';
+  } else {
+    document.querySelector('.error-email').textContent = '이메일을 확인해 주세요.';
+    document.querySelector('.error-password').textContent = '비밀번호를 확인해 주세요.';
+  }
+  $email.value = '';
+  $password.value = '';
+});
 
 function sendMyDataByEnter(event) {
   if(event.key === 'Enter') {
     sendMyData();
     event.preventDefault();
+    return;
   }
 }
 $email.addEventListener('keypress', sendMyDataByEnter);
@@ -65,16 +90,13 @@ $eyeBtn.onclick = function () {
   if($eyeBtn.firstElementChild.classList.contains('hidden-eye-btn')) {
     $eyeBtn.firstElementChild.classList.remove('hidden-eye-btn');
     $eyeBtn.lastElementChild.classList.add('hidden-eye-btn');
-    
   } else {
     $eyeBtn.firstElementChild.classList.add('hidden-eye-btn');
     $eyeBtn.lastElementChild.classList.remove('hidden-eye-btn');
-    
   }
   if($password.type === 'password') {
     $password.type = 'text';
   } else {
     $password.type = 'password';
   }
-
 }

--- a/js/signup.js
+++ b/js/signup.js
@@ -1,0 +1,162 @@
+const $email = document.querySelector('#email');
+const $password = document.querySelector('.password-first');
+const $passwordCheck = document.querySelector('.password-check');
+const $eyeBtn = document.querySelector('.eye-button');
+const $eyeBtnCheck = document.querySelector('.eye-button-check');
+const $loginBtn = document.querySelector('.buttton-login');
+
+function isEmailValid(email){
+  const validEmail = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,4}$/g;
+  return validEmail.test(email);
+}
+
+function handleCheckEmail(event) {
+  const email = this.value.trim();
+  const errorEmail = document.querySelector('.error-email');
+  if (email === '') {
+    event.target.classList.add('hidden');
+    errorEmail.textContent = '이메일을 입력해 주세요.';
+    return;
+  } else if (!isEmailValid(email)) {
+    event.target.classList.add('hidden');
+    errorEmail.textContent = '올바른 이메일 주소가 아닙니다.';
+    return;
+  } else if (email === isTest.email) {
+    event.target.classList.add('hidden');
+    errorEmail.textContent = '이미 사용 중인 이메일입니다.';
+    return;
+  } else {
+    errorEmail.textContent = ' ';
+    event.target.classList.remove('hidden');
+    return;
+  }
+}
+
+$email.addEventListener('focusout', handleCheckEmail);
+
+function isPwdValid(password){
+  const validPwd = /^(?=.*[a-zA-Z])(?=.*[0-9]).{8,}$/;
+  return validPwd.test(password);
+}
+
+function handleCheckPwd(event) {
+  const password = this.value.trim();
+  const errorPwd = document.querySelector('.error-password');
+  if (password === '') {
+    event.target.classList.add('hidden');
+    errorPwd.textContent = '비밀번호를 입력해 주세요.';
+    return;
+  } else if (!isPwdValid(password)) {
+    event.target.classList.add('hidden');
+    errorPwd.textContent = '비밀번호는 영문, 숫자 조합 8자 이상 입력해주세요.';
+    return;
+  } else {
+    errorPwd.textContent = ' ';
+    event.target.classList.remove('hidden');
+    return;
+  }
+}
+
+$password.addEventListener('focusout', handleCheckPwd);
+
+function handleFinallyCheckPwd(event) {
+  const passwordCheck = this.value.trim();
+  const errorPwd = document.querySelector('.error-password-check');
+  if (passwordCheck === '') {
+    event.target.classList.add('hidden');
+    errorPwd.textContent = '비밀번호를 입력해 주세요.';
+    return;
+  } else if ($passwordCheck.value !== $password.value) {
+    event.target.classList.add('hidden');
+    errorPwd.textContent = '비밀번호가 일치하지 않아요.';
+    return;
+  } else if ($passwordCheck.value === $password.value){
+    errorPwd.textContent = ' ';
+    event.target.classList.remove('hidden');
+    return;
+  }
+}
+
+$passwordCheck.addEventListener('focusout', handleFinallyCheckPwd);
+
+const isTest = {
+  email: "test@codeit.com",
+  password: "codeit101",
+};
+
+
+function sendMyData() {
+  if($email.classList.contains('hidden')) {
+    document.querySelector('.error-email').textContent = '이메일을 확인해 주세요.';
+  } else if($password.classList.contains('hidden')) {
+    document.querySelector('.error-password').textContent = '비밀번호를 확인해 주세요.';
+  } else if($passwordCheck.classList.contains('hidden')) {
+    document.querySelector('.error-password-check').textContent = '비밀번호를 확인해 주세요.';
+  } else {
+    location.href = '../folder.html';
+  }
+  $email.value = '';
+  $password.value = '';
+  $passwordCheck.value = '';
+}
+
+$loginBtn.addEventListener('submit', sendMyData);
+$loginBtn.addEventListener('click', function() {
+  if($loginBtn.type === 'submit') {
+    $loginBtn.type = 'button';
+  }
+  if($email.classList.contains('hidden')) {
+    document.querySelector('.error-email').textContent = '이메일을 확인해 주세요.';
+  } else if($password.classList.contains('hidden')) {
+    document.querySelector('.error-password').textContent = '비밀번호를 확인해 주세요.';
+  } else if($passwordCheck.classList.contains('hidden')) {
+    document.querySelector('.error-password-check').textContent = '비밀번호를 확인해 주세요.';
+  } else {
+    location.href = '../folder.html';
+  }
+  $email.value = '';
+  $password.value = '';
+  $passwordCheck.value = '';
+});
+
+function sendMyDataByEnter(event) {
+  if(event.key === 'Enter') {
+    sendMyData();
+    event.preventDefault();
+    return;
+  }
+}
+$email.addEventListener('keypress', sendMyDataByEnter);
+$password.addEventListener('keypress', sendMyDataByEnter);
+$passwordCheck.addEventListener('keypress', sendMyDataByEnter);
+
+
+$eyeBtn.onclick = function () {
+  if($eyeBtn.firstElementChild.classList.contains('hidden-eye-btn')) {
+    $eyeBtn.firstElementChild.classList.remove('hidden-eye-btn');
+    $eyeBtn.lastElementChild.classList.add('hidden-eye-btn');
+  } else {
+    $eyeBtn.firstElementChild.classList.add('hidden-eye-btn');
+    $eyeBtn.lastElementChild.classList.remove('hidden-eye-btn');
+  }
+  if($password.type === 'password') {
+    $password.type = 'text';
+  } else {
+    $password.type = 'password';
+  }
+}
+
+$eyeBtnCheck.onclick = function () {
+  if($eyeBtnCheck.firstElementChild.classList.contains('hidden-eye-btn')) {
+    $eyeBtnCheck.firstElementChild.classList.remove('hidden-eye-btn');
+    $eyeBtnCheck.lastElementChild.classList.add('hidden-eye-btn');
+  } else {
+    $eyeBtnCheck.firstElementChild.classList.add('hidden-eye-btn');
+    $eyeBtnCheck.lastElementChild.classList.remove('hidden-eye-btn');
+  }
+  if($passwordCheck.type === 'password') {
+    $passwordCheck.type = 'text';
+  } else {
+    $passwordCheck.type = 'password';
+  }
+}

--- a/signup.html
+++ b/signup.html
@@ -23,19 +23,32 @@
           <div class="sign-input-box">
             <label for="email" class="email">이메일</label>
             <input id="email" name="email" />
+            <div class="error-email"></div>
           </div>
           <div class="sign-input-box box-password">
             <label for="password" class="password">비밀번호</label>
-            <input class="password-input" name="password" type="password" />
+            <input
+              class="password-input password-first"
+              name="password"
+              type="password"
+            />
+            <div class="error-password"></div>
             <button class="eye-button" type="button">
-              <img src="./img/eye-off.svg" />
+              <img src="./img/eye-off.svg" class="eye-off" />
+              <img src="./img/eye-on.svg" class="eye-on hidden-eye-btn" />
             </button>
           </div>
           <div class="sign-input-box box-password">
             <label for="password" class="password">비밀번호 확인</label>
-            <input class="password-input" name="password" type="password" />
-            <button class="eye-button" type="button">
-              <img src="./img/eye-off.svg" />
+            <input
+              class="password-input password-check"
+              name="password"
+              type="password"
+            />
+            <div class="error-password-check"></div>
+            <button class="eye-button-check" type="button">
+              <img src="./img/eye-off.svg" class="eye-off" />
+              <img src="./img/eye-on.svg" class="eye-on hidden-eye-btn" />
             </button>
           </div>
         </div>
@@ -53,5 +66,6 @@
         </div>
       </div>
     </div>
+    <script src="./js/signup.js"></script>
   </body>
 </html>

--- a/src/signin.css
+++ b/src/signin.css
@@ -110,6 +110,12 @@ header {
   border-color: var(--primary);
 }
 
+.error-email,
+.error-password {
+  color: var(--red);
+  font-size: 1.2rem;
+  font-weight: 300;
+}
 .eye-button {
   position: absolute;
   bottom: 3.7rem;

--- a/src/signup.css
+++ b/src/signup.css
@@ -88,6 +88,13 @@ header {
   font-size: 1.4rem;
   font-weight: 400;
 }
+#email.hidden {
+  border: 0.1rem solid var(--red);
+}
+
+.password-input.hidden {
+  border: 0.1rem solid var(--red);
+}
 
 #email,
 .password-input {
@@ -103,12 +110,32 @@ header {
   border-color: var(--primary);
 }
 
+.error-email,
+.error-password,
+.error-password-check {
+  color: var(--red);
+  font-size: 1.2rem;
+  font-weight: 300;
+}
+
 .eye-button {
   position: absolute;
-  bottom: 2.2rem;
+  bottom: 3.5rem;
   right: 1.5rem;
   width: 1.6rem;
   height: 1.6rem;
+}
+
+.eye-button-check {
+  position: absolute;
+  bottom: 3.7rem;
+  right: 1.5rem;
+  width: 1.6rem;
+  height: 1.6rem;
+}
+
+.hidden-eye-btn {
+  display: none;
 }
 
 .buttton-login {


### PR DESCRIPTION
## 요구사항

### 기본
- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [x] [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [x] [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [x] [기본]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화
- [x] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [x] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [ ] [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항
- 회원가입 페이지 JS 추가

## 스크린샷
![회원가입 페이지](https://github.com/codeit-bootcamp-frontend/5-Weekly-Mission/assets/49749101/78d3bb42-e64d-4550-b57c-11775f430e4f)

## 멘토에게

- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
- 파트1 기간 동안 정말 감사했습니다 :)