### PR TITLE
[이남경] Week5

### DIFF
--- a/css/global.css
+++ b/css/global.css
@@ -4,19 +4,20 @@
   box-sizing: border-box;
   margin: 0;
   color: inherit;
-  text-decoration: none; 
-  --Primary: #6D6AFE;
-  --Red: #FF5B56;
+  text-decoration: none;
+  --Primary: #6d6afe;
+  --Red: #ff5b56;
   --Black: #111322;
-  --White: #FFFFFF;
-  --Gray1: #3E3E43;
-  --Gray2: #9FA6B2;
-  --Gray3: #CCD5E3;
-  --Gray4: #E7EFFB;
-  --Gray5: #F0F6FF;
+  --White: #ffffff;
+  --Gray1: #3e3e43;
+  --Gray2: #9fa6b2;
+  --Gray3: #ccd5e3;
+  --Gray4: #e7effb;
+  --Gray5: #f0f6ff;
 }
 
 body {
-  font-size: 18px;
-  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto, 'Helvetica Neue', 'Segoe UI', 'Apple SD Gothic Neo', 'Noto Sans KR', 'Malgun Gothic', sans-serif;
+  font-family: Pretendard, -apple-system, BlinkMacSystemFont, system-ui, Roboto,
+    "Helvetica Neue", "Segoe UI", "Apple SD Gothic Neo", "Noto Sans KR",
+    "Malgun Gothic", sans-serif;
 }

--- a/css/sign-in.style.css
+++ b/css/sign-in.style.css
@@ -164,8 +164,7 @@ i {
 
 /* 에러 메시지 */
 
-.email-error-message,
-.password-error-message {
+.error-message {
   margin: 6px 0 0 0;
   font-size: 14px;
   color: var(--Red);

--- a/css/sign-in.style.css
+++ b/css/sign-in.style.css
@@ -164,7 +164,7 @@ i {
 
 /* 에러 메시지 */
 
-.error-message {
+.input--helper-text__error {
   margin: 6px 0 0 0;
   font-size: 14px;
   color: var(--Red);

--- a/css/sign-up.style.css
+++ b/css/sign-up.style.css
@@ -75,10 +75,10 @@ input.email {
   background: var(--Linkbrary-white, #FFF);
 }
 
-/* input:focus {
-  border: 1px solid red;
+.email:focus {
+  border: 1px solid var(--Primary);
   background: var(--Linkbrary-white, #FFF);
-} */
+}
 
 .input-binder {
   width: 100%;
@@ -97,10 +97,10 @@ input.password {
   background: var(--Linkbrary-white, #FFF);
 }
 
-/* .password:focus {
-  border: 1px solid var(--Linkbrary-primary-color, #6D6AFE);
+.password:focus {
+  border: 1px solid var(--Primary);
   background: var(--Linkbrary-white, #FFF);
-} */
+}
 
 i {
   position: absolute;
@@ -160,4 +160,17 @@ i {
   .main {
     padding: 0 32px;
   }
+}
+
+/* 에러 메시지 */
+
+.error-message {
+  margin: 6px 0 0 0;
+  font-size: 14px;
+  color: var(--Red);
+  text-align: left;
+}
+
+input.error-border {
+  border: 1px solid var(--Red);
 }

--- a/css/sign-up.style.css
+++ b/css/sign-up.style.css
@@ -164,7 +164,7 @@ i {
 
 /* 에러 메시지 */
 
-.error-message {
+.input--helper-text__error {
   margin: 6px 0 0 0;
   font-size: 14px;
   color: var(--Red);

--- a/js/sign-up.js
+++ b/js/sign-up.js
@@ -97,6 +97,12 @@ const passwordErrorMessage = document.querySelector('.password-error-message');
 const passwordP = document.createElement('p');
 passwordP.classList.add('input--helper-text__error');
 
+const passwordFirstInput = document.querySelector('.password--first-input');
+const passwordSecondInput = document.querySelector('.password--second-input');
+const inputPasswordFirst = document.querySelector('.input-password--first');
+const inputPasswordSecond = document.querySelector('.input-password--second');
+
+
 // 비밀번호 값 입력했는지 확인하는 함수
 function validatePasswordInput() {
   if (!passwordInput.value) {
@@ -122,17 +128,32 @@ function resetPasswordErrorMessage() {
   passwordP.textContent = '';
 }
 
-// signup.html 한정 함수 추가) 비밀번호 유효성 검사 함수
+// 비밀번호 유효성 검사 함수
 function validatePassword() {
-  // 비밀번호 형식 검증
   if (passwordInput.value.length < 8 || !/[a-zA-Z]/.test(passwordInput.value) || !/[0-9]/.test(passwordInput.value)) {
+    // 첫번째 박스 아래 에러 메시지 노출
     passwordP.textContent = '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.';
+    inputPasswordFirst.appendChild(passwordP);
+
+    // 첫번째 박스 테두리 빨간색으로 변경
+    passwordFirstInput.classList.add('error-border');  
+
   }
 }
 
-passwordInput.addEventListener('focusout', () => {
-  validatePasswordInput();
-  validatePassword();
-});
+// 비밀번호 값과 비밀번호 확인 값 일치하는지 확인하는 함수
+function validatePasswordConfirmation() {
+  if (!(passwordFirstInput.value === passwordSecondInput.value)) {
+    // 두번째 박스 아래 에러 메시지 노출
+    passwordP.textContent = '비밀번호가 일치하지 않아요.';
+    inputPasswordSecond.appendChild(passwordP);
 
+    // 두번째 박스 테두리 빨간색으로 변경
+    passwordSecondInput.classList.add('error-border');  
+  }
+}
+
+passwordInput.addEventListener('focusout', validatePasswordInput);
 passwordInput.addEventListener('focusin', resetPasswordErrorMessage);
+passwordFirstInput.addEventListener('focusout', validatePassword); 
+passwordSecondInput.addEventListener('focusout', validatePasswordConfirmation);

--- a/js/sign-up.js
+++ b/js/sign-up.js
@@ -1,3 +1,11 @@
+// import {
+//   validateEmailInput,
+//   validateEmailFormat,
+//   resetEmailErrorMessage,
+//   validatePasswordInput,
+//   resetPasswordErrorMessage
+// } from "./sign.js";
+
 // *---* 이메일 에러메시지 *---* //
 
 const inputEmail = document.querySelector('.input-email');
@@ -58,9 +66,23 @@ function resetEmailErrorMessage() {
   emailP.textContent = '';
 }
 
+// signup.html 한정 함수 추가) 이메일 중복 검사하는 함수
+
+function checkEmailUnique() {
+  if (emailInput.value === 'test@codeit.com') { // 입력한 이메일 주소가 test@codeit.com 일 때
+    // 박스 아래 에러 메시지 노출
+    emailP.textContent = '이미 사용 중인 이메일입니다.';
+    inputEmail.appendChild(emailP);
+
+    // 박스 테두리 빨간색으로 변경
+    emailInput.classList.add('error-border');
+  }
+}
+
 emailInput.addEventListener('focusout', () => {
   validateEmailInput();
   validateEmailFormat();
+  checkEmailUnique();
 });
 
 emailInput.addEventListener('focusin', resetEmailErrorMessage);
@@ -100,36 +122,17 @@ function resetPasswordErrorMessage() {
   passwordP.textContent = '';
 }
 
-passwordInput.addEventListener('focusout', validatePasswordInput);
-passwordInput.addEventListener('focusin', resetPasswordErrorMessage);
-
-
-
-// *---* 로그인 시도 에러메시지 *---* //
-
-// test ID/PW와 일치할 경우 로그인 버튼 클릭 시 folder 페이지로 이동
-
-const loginBtn = document.querySelector('.login .button');
-
-function goFolder() {
-  if (emailInput.value === "test@codeit.com" && passwordInput.value === "codeit101") {
-    let link = '/folder';
-    location.href = link;
-  } else { 
-    // 이외의 이메일 ID 입력 후 로그인 버튼 클릭 시 에러 메시지 노출
-    emailP.textContent = '이메일을 확인해 주세요.';
-    inputEmail.appendChild(emailP);
-    
-    // 이메일 박스 테두리 빨간색으로 변경
-    emailInput.classList.add('error-border');
-
-    // 이외의 패스워드 입력 후 로그인 버튼 클릭 시 에러 메시지 노출
-    passwordP.textContent = '비밀번호를 확인해 주세요.';
-    inputPassword.appendChild(passwordP);
-
-    // 패스워드 박스 테두리 빨간색으로 변경
-    passwordInput.classList.add('error-border');
+// signup.html 한정 함수 추가) 비밀번호 유효성 검사 함수
+function validatePassword() {
+  // 비밀번호 형식 검증
+  if (passwordInput.value.length < 8 || !/[a-zA-Z]/.test(passwordInput.value) || !/[0-9]/.test(passwordInput.value)) {
+    passwordP.textContent = '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.';
   }
 }
 
-loginBtn.addEventListener('click', goFolder);
+passwordInput.addEventListener('focusout', () => {
+  validatePasswordInput();
+  validatePassword();
+});
+
+passwordInput.addEventListener('focusin', resetPasswordErrorMessage);

--- a/js/sign.js
+++ b/js/sign.js
@@ -107,29 +107,29 @@ passwordInput.addEventListener('focusin', resetPasswordErrorMessage);
 
 // *---* 로그인 시도 에러메시지 *---* //
 
-// test ID/PW와 일치할 경우 로그인 버튼 클릭 시 folder 페이지로 이동
-
 const loginBtn = document.querySelector('.login .button');
 
 function goFolder() {
+  // test ID/PW와 일치할 경우 로그인 버튼 클릭 시 folder 페이지로 이동
   if (emailInput.value === "test@codeit.com" && passwordInput.value === "codeit101") {
     let link = '/folder';
     location.href = link;
-  } else { 
-    // 이외의 이메일 ID 입력 후 로그인 버튼 클릭 시 에러 메시지 노출
-    emailP.textContent = '이메일을 확인해 주세요.';
-    inputEmail.appendChild(emailP);
-    
-    // 이메일 박스 테두리 빨간색으로 변경
-    emailInput.classList.add('error-border');
+    return;
+  } 
 
-    // 이외의 패스워드 입력 후 로그인 버튼 클릭 시 에러 메시지 노출
-    passwordP.textContent = '비밀번호를 확인해 주세요.';
-    inputPassword.appendChild(passwordP);
+  // 이외의 이메일 ID 입력 후 로그인 버튼 클릭 시 에러 메시지 노출
+  emailP.textContent = '이메일을 확인해 주세요.';
+  inputEmail.appendChild(emailP);
+  
+  // 이메일 박스 테두리 빨간색으로 변경
+  emailInput.classList.add('error-border');
 
-    // 패스워드 박스 테두리 빨간색으로 변경
-    passwordInput.classList.add('error-border');
-  }
+  // 이외의 패스워드 입력 후 로그인 버튼 클릭 시 에러 메시지 노출
+  passwordP.textContent = '비밀번호를 확인해 주세요.';
+  inputPassword.appendChild(passwordP);
+
+  // 패스워드 박스 테두리 빨간색으로 변경
+  passwordInput.classList.add('error-border');
 }
 
 loginBtn.addEventListener('click', goFolder);

--- a/js/sign.js
+++ b/js/sign.js
@@ -5,7 +5,7 @@ const emailInput = document.querySelector('.email');
 const emailErrorMessage = document.querySelector('.email-error-message');
 
 const emailP = document.createElement('p');
-emailP.classList.add('error-message');
+emailP.classList.add('input--helper-text__error');
 
 // 이메일 값 입력했는지 확인하는 함수
 function validateEmailInput() {
@@ -38,18 +38,15 @@ function validateEmailFormat() {
 
   // 이메일 형식 검증
   const emailRegex = /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-  const isValidEmail = emailRegex.test(email);
 
   // 에러 메시지 처리
-  if (!isValidEmail) {
-    if (!emailErrorMessage) {
-      // 박스 아래 에러 메시지 노출
-      emailP.textContent = '올바른 이메일 주소가 아닙니다.';
-      inputEmail.appendChild(emailP);
+  if (!emailRegex.test(email)) {
+    // 박스 아래 에러 메시지 노출
+    emailP.textContent = '올바른 이메일 주소가 아닙니다.';
+    inputEmail.appendChild(emailP);
 
-      // 박스 테두리 빨간색으로 변경
-      emailInput.classList.add('error-border');
-    }
+    // 박스 테두리 빨간색으로 변경
+    emailInput.classList.add('error-border');
   } else {
     // 박스 테두리 빨간색으로 변경하는 클래스 제거
     emailInput.classList.remove('error-border');
@@ -58,6 +55,12 @@ function validateEmailFormat() {
     emailP.textContent = '';
   }
 }
+
+// 이메일 중복 검사하는 함수
+
+
+
+
 
 // 포커스 인 되면 에러메시지 리셋하는 함수
 function resetEmailErrorMessage() {
@@ -77,7 +80,7 @@ const passwordInput = document.querySelector('.password');
 const passwordErrorMessage = document.querySelector('.password-error-message');
 
 const passwordP = document.createElement('p');
-passwordP.classList.add('error-message');
+passwordP.classList.add('input--helper-text__error');
 
 // 비밀번호 값 입력했는지 확인하는 함수
 function validatePasswordInput() {
@@ -137,3 +140,5 @@ function goFolder() {
 }
 
 loginBtn.addEventListener('click', goFolder);
+
+

--- a/js/sign.js
+++ b/js/sign.js
@@ -5,7 +5,7 @@ const emailInput = document.querySelector('.email');
 const emailErrorMessage = document.querySelector('.email-error-message');
 
 const emailP = document.createElement('p');
-emailP.classList.add('email-error-message');
+emailP.classList.add('error-message');
 
 // 이메일 값 입력했는지 확인하는 함수
 function validateEmailInput() {
@@ -77,7 +77,7 @@ const passwordInput = document.querySelector('.password');
 const passwordErrorMessage = document.querySelector('.password-error-message');
 
 const passwordP = document.createElement('p');
-passwordP.classList.add('password-error-message');
+passwordP.classList.add('error-message');
 
 // 비밀번호 값 입력했는지 확인하는 함수
 function validatePasswordInput() {

--- a/js/sign.js
+++ b/js/sign.js
@@ -10,14 +10,12 @@ emailP.classList.add('input--helper-text__error');
 // 이메일 값 입력했는지 확인하는 함수
 function validateEmailInput() {
   if (!emailInput.value) {
-    if (!emailErrorMessage) {
-      // 박스 아래 에러 메시지 노출
-      emailP.textContent = '이메일을 입력해 주세요.';
-      inputEmail.appendChild(emailP);
+    // 박스 아래 에러 메시지 노출
+    emailP.textContent = '이메일을 입력해 주세요.';
+    inputEmail.appendChild(emailP);
 
-      // 박스 테두리 빨간색으로 변경
-      emailInput.classList.add('error-border');
-    }
+    // 박스 테두리 빨간색으로 변경
+    emailInput.classList.add('error-border');
   } else {
     // 박스 테두리 빨간색으로 변경하는 클래스 제거
     emailInput.classList.remove('error-border');

--- a/signup.html
+++ b/signup.html
@@ -46,18 +46,18 @@
                 placeholder="codeit@gmail.com"
               />
             </section>
-            <section class="input-password">
+            <section class="input-password input-password--first">
               <label class="label" for="비밀번호">비밀번호</label>
               <div class="input-binder">
-                <input class="password" type="password" />
+                <input class="password password--first-input" type="password" />
                 <!-- <img src="/images/eye-off.png" alt="eye-off"> -->
                 <i class="fas fa-eye" style="color: #4a4a4a"></i>
               </div>
             </section>
-            <section class="input-password">
+            <section class="input-password input-password--second">
               <label class="label" for="비밀번호">비밀번호 확인</label>
               <div class="input-binder">
-                <input class="password" type="password" />
+                <input class="password password--second-input" type="password" />
                 <!-- <img src="/images/eye-off.png" alt="eye-off"> -->
                 <i class="fas fa-eye" style="color: #4a4a4a"></i>
               </div>

--- a/signup.html
+++ b/signup.html
@@ -80,5 +80,6 @@
         </div>
       </section>
     </main>
+    <script src="js/sign.js"></script>
   </body>
 </html>

--- a/signup.html
+++ b/signup.html
@@ -80,6 +80,6 @@
         </div>
       </section>
     </main>
-    <script src="js/sign.js"></script>
+    <script src="js/sign-up.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## 요구사항

https://weekly-mission-erin.netlify.app/signup

### 기본

- [x] [기본]이메일 input에서 focus out 할 때, 값이 없을 경우 input에 빨강색 테두리와 아래에 “이메일을 입력해주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 할 때, 이메일 형식에 맞지 않는 값이 있는 경우 input에 빨강색 테두리와 아래에 “올바른 이메일 주소가 아닙니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]이메일 input에서 focus out 일 때, input 값이 test@codeit.com 일 경우 input에 빨강색 테두리와 아래에 “이미 사용 중인 이메일입니다.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input에서 focus out 할 때, 값이 8자 미만으로 있거나 문자열만 있거나 숫자만 있는 경우, input에 빨강색 테두리와 아래에 “비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.” 빨강색 에러 메세지가 보이나요?
- [x] [기본]비밀번호 input과 비밀번호 확인 input의 값이 다른 경우, 비밀번호 확인 input에 빨강색 테두리와 아래에 “비밀번호가 일치하지 않아요.” 빨강색 에러 메세지가 보이나요?
- [ ] [기본]회원가입을 실행할 경우, 문제가 있는 경우 문제가 있는 input에 빨강색 테두리와 에러 메세지가 보이나요?
- [ ] [기본]이외의 유효한 회원가입 시도의 경우, “/folder”로 이동하나요?
- [ ] [기본]회원가입 버튼 클릭 또는 Enter키 입력으로 회원가입 되나요?
- [ ] [기본]이메일, 비밀번호, 비밀번호 확인 input에 에러 관련 디자인을 Components 영역의 에러 케이스로 적용했나요?

### 심화

- [ ] [심화]눈 모양 아이콘 클릭시 비밀번호의 문자열이 보이기도 하고, 가려지기도 하나요?
- [ ] [심화]비밀번호의 문자열이 가려질 때는 눈 모양 아이콘에는 사선이 그어져있고, 비밀번호의 문자열이 보일 때는 사선이 없는 눈 모양 아이콘이 보이나요?
- [ ] [심화]로그인, 회원가입 페이지에 공통적으로 사용하는 로직이 있다면, 반복하지 않고 공통된 로직을 모듈로 분리해 사용했나요?

## 주요 변경사항

## 스크린샷

## 멘토에게

- 5주차 요청사항은 이어서 개발하겠습니다.. ㅠ
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
