### PR TITLE
[오동혁] Week6

### DIFF
--- a/js/signin.js
+++ b/js/signin.js
@@ -1,4 +1,4 @@
-import { checkEmail, changeType, toggleInputBorder } from './signup.js';
+import { checkEmailType, changeType, toggleInputBorder } from './signup.js';
 
 const $email = document.querySelector('#email-input');
 const $password = document.querySelector('#password-input');
@@ -9,16 +9,35 @@ function login(e) {
   if (e.target.type == 'submit') e.preventDefault();
   if (e.type == 'keyup' && e.keyCode != '13') return; 
 
-  if ($email.value == 'test@codeit.com' && $password.value == 'codeit101') {
+  fetch("https://bootcamp-api.codeit.kr/api/sign-in", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      "email": $email.value,
+      "password": $password.value,
+    }),
+  })
+  .then((response) => {
+    if (response.status === 200) {
+      return response.json();
+    } else {
+      throw new Error('로그인 오류');
+    }
+  })
+  .then((result) => {
+    localStorage.setItem('accessToken', result.data.accessToken);
     location.href = 'folder';
-  } else {
+  })
+  .catch(() => {
     $emailMsg.textContent = '이메일을 확인해주세요.';
     $passwordMsg.textContent = '비밀번호를 확인해 주세요.';
     $emailMsg.hidden = false;
     $passwordMsg.hidden = false;
     toggleInputBorder($emailMsg.hidden, $email);
     toggleInputBorder($passwordMsg.hidden, $password);
-  }
+  });
 }
 
 function checkPwdEmpty(e) {
@@ -30,7 +49,7 @@ function checkPwdEmpty(e) {
   toggleInputBorder($passwordMsg.hidden, e.target);
 }
 
-$email.addEventListener('focusout', checkEmail);
+$email.addEventListener('focusout', checkEmailType);
 $password.addEventListener('focusout', checkPwdEmpty);
 document.querySelector('#password-img').addEventListener('click', changeType);
 document.querySelector('#login').addEventListener('keyup', login);


### PR DESCRIPTION
## 요구사항

### 기본

- [x] [기본/로그인 페이지]
https://bootcamp-api.codeit.kr/docs 에 명세된 “/api/sign-in”으로 { “email”: “test@codeit.com”, “password”: “sprint101” } POST 요청해서 성공 응답을 받고 “/folder”로 이동하나요?
- [x] [기본/회원가입 페이지]
이메일 input에서 “test@codeit.com”으로 “/api/check-email” 이메일 중복 확인 POST 요청하면 이메일 중복 에러를 확인할 수 있나요?
- [x] [기본/회원가입 페이지]
유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?

### 심화

- [x] 로그인/회원가입시 성공 응답으로 받은 accessToken을 로컬 스토리지에 저장했나요?
- [x] 로그인/회원가입 페이지에 접근시 로컬 스토리지에 accessToken이 있는 경우 “/folder” 페이지로 이동하나요?

## 주요 변경사항

- https://bootcamp-api.codeit.kr/docs 에 명시된 api를 사용하여 회원가입, 로그인 구현
- netlify url: https://5-weekly-ohdonghyeok.netlify.app/

## 스크린샷

## 멘토에게
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
