### PR TITLE
[이진욱] Week6

### DIFF
--- a/script/signin.js
+++ b/script/signin.js
@@ -8,25 +8,35 @@ import {
   validateEmailValue,
   validatePwValue,
   handlePwSight,
-  mockUserInfo,
   drawAlert,
   message,
   eraseAlert,
+  url,
 } from './utils/auth.js';
+import { signInAccess } from './utils/api.js';
 
-// 임시 계정 일치 검사 || 경고 메시지 출력
-const submitEvent = (event) => {
+if (localStorage.getItem('signInAccessToken')) location.href = url.folderPage;
+
+const submitEvent = async (event) => {
   const { value: emailValue } = $emailInput;
   const { value: pwValue } = $pwInput;
   event.preventDefault();
 
-  if (emailValue === mockUserInfo.email && pwValue === mockUserInfo.pw) return (location.href = '../pages/folder.html');
-  pwValue !== mockUserInfo.pw //
-    ? drawAlert($pwAlertDiv, $pwInput, message.wrongPw)
-    : eraseAlert($pwAlertDiv, $pwInput);
-  emailValue !== mockUserInfo.email
-    ? drawAlert($emailAlertDiv, $emailInput, message.wrongEmail)
-    : eraseAlert($emailAlertDiv, $emailInput);
+  let result;
+  try {
+    result = await signInAccess(emailValue, pwValue);
+  } catch (error) {
+    drawAlert($pwAlertDiv, $pwInput, message.wrongAccout);
+    drawAlert($emailAlertDiv, $emailInput, message.wrongAccout);
+    console.error(error);
+    return;
+  }
+
+  if (result.data) {
+    const { accessToken, refreshToken } = result.data;
+    localStorage.setItem('signInAccessToken', accessToken);
+    location.href = url.folderPage;
+  }
 };
 
 $emailInput.addEventListener('focusout', validateEmailValue);

--- a/script/utils/api.js
+++ b/script/utils/api.js
@@ -1,0 +1,54 @@
+const CODEIT_URL = `https://bootcamp-api.codeit.kr/api`;
+
+export const signInAccess = async (email, password) => {
+  const response = await fetch(`${CODEIT_URL}/sign-in`, {
+    method: 'POST',
+    headers: {
+      'Content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      email: email,
+      password: password,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error('로그인에 실패했습니다.');
+  }
+  const body = await response.json();
+  return body;
+};
+
+export const checkEmailAccess = async (email) => {
+  const response = await fetch(`${CODEIT_URL}/check-email`, {
+    method: 'POST',
+    headers: {
+      'Content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      email: email,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error('이메일이 이미 존재합니다.');
+  }
+  const body = await response.json();
+  return body;
+};
+
+export const signUpAccess = async (email, password) => {
+  const response = await fetch(`${CODEIT_URL}/sign-up`, {
+    method: 'POST',
+    headers: {
+      'Content-type': 'application/json',
+    },
+    body: JSON.stringify({
+      email: email,
+      password: password,
+    }),
+  });
+  if (!response.ok) {
+    throw new Error('회원가입에 실패했습니다.');
+  }
+  const body = await response.json();
+  return body;
+};

--- a/script/utils/auth.js
+++ b/script/utils/auth.js
@@ -8,11 +8,6 @@ export const $pwAlertDiv = document.querySelector('#wrong_password_message');
 export const $pwVerifyAlertDiv = document.querySelector('#wrong_password_repeat_message');
 export const $form = document.querySelector('#form');
 
-export const mockUserInfo = {
-  email: 'test@codeit.kr',
-  pw: 'codeit101',
-};
-
 export const signupPageStatus = {
   duplicateAccountState: false,
   pwFormState: false,
@@ -22,12 +17,18 @@ export const signupPageStatus = {
 export const message = {
   inputEmail: '이메일을 입력해주세요.',
   inputPw: '비밀번호를 입력해주세요.',
+  wrongAccout: '이메일 혹은 비밀번호를 확인해주세요.',
   wrongEmail: '이메일을 확인해주세요.',
   wrongPw: '비밀번호를 확인해주세요.',
   wrongPwForm: '비밀번호는 영문, 숫자 조합 8자 이상 입력해 주세요.',
   wrongEmailForm: '올바른 이메일 주소가 아닙니다.',
   duplicateEmail: '이미 사용 중인 이메일입니다.',
   diffrentPw: '비밀번호가 일치하지 않아요.',
+};
+
+export const url = {
+  folderPage: '/pages/folder.html',
+  landingPage: 'index.html',
 };
 
 // 경고메시지 그리기
@@ -60,9 +61,12 @@ export const validateEmailValue = () => {
     drawAlert($emailAlertDiv, $emailInput, message.inputEmail);
   } else if (emailValue) {
     eraseAlert($emailAlertDiv, $emailInput);
-    emailPattern.test(emailValue) === false
-      ? drawAlert($emailAlertDiv, $emailInput, message.wrongEmailForm)
-      : eraseAlert($emailAlertDiv, $emailInput);
+    if (!emailPattern.test(emailValue)) {
+      drawAlert($emailAlertDiv, $emailInput, message.wrongEmailForm);
+    } else {
+      eraseAlert($emailAlertDiv, $emailInput);
+      return true;
+    }
   }
 };
 


### PR DESCRIPTION
## 요구사항

### 기본

- [x] https://bootcamp-api.codeit.kr/docs 에 명세된 “/api/sign-in”으로 { “email”: “test@codeit.com”, “password”: “sprint101” } POST 요청해서 성공 응답을 받고 “/folder”로 이동하나요?
- [x] 이메일 input에서 “test@codeit.com”으로 “/api/check-email” 이메일 중복 확인 POST 요청하면 이메일 중복 에러를 확인할 수 있나요?
- [x] 유효한 회원가입 형식의 경우 “/api/sign-up” POST 요청하고 성공 응답을 받으면 “/folder”로 이동하나요?

### 심화

- [x] 로그인/회원가입시 성공 응답으로 받은 accessToken을 로컬 스토리지에 저장했나요?
- [x] 로그인/회원가입 페이지에 접근시 로컬 스토리지에 accessToken이 있는 경우 “/folder” 페이지로 이동하나요?

## 주요 변경사항

- api 리퀘스트 부분을 모듈화하여 분리했습니다.

## 스크린샷

![image](이미지url)

## 멘토에게

https://resilient-tapioca-37feb1.netlify.app/
- 로그인 페이지에서 요구되는 계정 정보가 지난 주차 때의 계정 정보와 살짝 달라 혼동이 좀 있었는데 이러한 부분도 의도된 부분일까요?
- 셀프 코드 리뷰를 통해 질문 이어가겠습니다.
